### PR TITLE
Update gradle files

### DIFF
--- a/examples/android-demo/app/build.gradle
+++ b/examples/android-demo/app/build.gradle
@@ -39,7 +39,10 @@ repositories {
     }
     maven {
         url  "http://oss.jfrog.org/oss-snapshot-local/"
-    }    
+    }
+    flatDir {
+        dirs '../../../lightstep-tracer-android/build/outputs/aar'
+    }
 }
 
 dependencies {
@@ -49,5 +52,8 @@ dependencies {
     compile 'com.android.volley:volley:1.0.0'
     compile 'io.opentracing:opentracing-api:0.1.0-SNAPSHOT'
 
+    // Toggle the below to use the code in the source tree rather than the
+    // published version
     compile 'com.lightstep.tracer:lightstep-tracer-android:' + current_version
+    //compile(name:'lightstep-tracer-android-release', ext:'aar')
 }

--- a/examples/android-simple/app/build.gradle
+++ b/examples/android-simple/app/build.gradle
@@ -34,6 +34,9 @@ repositories {
     maven {
         url  "http://oss.jfrog.org/oss-snapshot-local/"
     }
+    flatDir {
+        dirs '../../../lightstep-tracer-android/build/outputs/aar'
+    }
 }
 
 dependencies {
@@ -43,5 +46,8 @@ dependencies {
     compile 'com.android.support:design:23.3.0'
     compile 'io.opentracing:opentracing-api:0.1.0-SNAPSHOT'
 
+    // Toggle the below to use the code in the source tree rather than the
+    // published version
     compile 'com.lightstep.tracer:lightstep-tracer-android:' + current_version
+    //compile(name:'lightstep-tracer-android-release', ext:'aar')
 }

--- a/lightstep-tracer-android/build.gradle
+++ b/lightstep-tracer-android/build.gradle
@@ -119,9 +119,11 @@ repositories {
 
 dependencies {
     compile 'io.opentracing:opentracing-api:0.1.0-SNAPSHOT'
-    compile 'org.apache.thrift:libthrift:0.9.2'
+    compile('org.apache.thrift:libthrift:0.9.2') {
+        // Not needed on Android
+        exclude module: 'httpclient'
+    }
     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.3'
-    compile 'org.json:json:20160212'
     compile 'javax.annotation:jsr250-api:1.0'
 }
 


### PR DESCRIPTION
## Summary

Addresses two dependency version conflict warnings in the Android AAR build:

```bash
$ ./gradlew install
WARNING: Dependency org.apache.httpcomponents:httpclient:4.2.5 is ignored for debug as it may be conflicting with the internal version provided by Android.
         In case of problem, please repackage it with jarjar to change the class packages
WARNING: Dependency org.json:json:20160212 is ignored for debug as it may be conflicting with the internal version provided by Android.
         In case of problem, please repackage with jarjar to change the class packages
```

Thought unrelated to the fix, this also adds configuration to the examples so it is easier to toggle between building against the published artifacts and the locally built artifacts.