### PR TITLE
Add flush at shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,5 +45,6 @@ pre-publish:
 	@echo "\033[92mPublishing as $$BINTRAY_USER with key <HIDDEN> \033[0m"
 
 # CircleCI test
-ci_test:
+ci_test: build-libs
 	make -C lightstep-tracer-jre test
+	make -C examples/jre-simple run

--- a/examples/jre-simple/src/main/java/Simple.java
+++ b/examples/jre-simple/src/main/java/Simple.java
@@ -14,9 +14,6 @@ public class Simple {
 
         Tracer tracer = new com.lightstep.tracer.jre.JRETracer(
             new com.lightstep.tracer.shared.Options("{your_access_token}")
-                .withCollectorHost("localhost")
-                .withCollectorPort(9998)
-                .withCollectorEncryption(com.lightstep.tracer.shared.Options.Encryption.NONE)
         );
 
         // Create an outer span to capture all activity

--- a/examples/jre-simple/src/main/java/Simple.java
+++ b/examples/jre-simple/src/main/java/Simple.java
@@ -1,38 +1,143 @@
 
 import io.opentracing.Span;
 import io.opentracing.Tracer;
-import com.lightstep.tracer.jre.JRETracer;
-import com.lightstep.tracer.shared.*;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class Simple {
-    public static void main(String[] args) {
+
+
+    public static void main(String[] args) throws InterruptedException {
         System.out.println("Starting Simple example...");
 
-        Tracer tracer = new JRETracer(
-            new Options("{your_access_token}")
+        Tracer tracer = new com.lightstep.tracer.jre.JRETracer(
+            new com.lightstep.tracer.shared.Options("{your_access_token}")
+                .withCollectorHost("localhost")
+                .withCollectorPort(9998)
+                .withCollectorEncryption(com.lightstep.tracer.shared.Options.Encryption.NONE)
         );
 
-        Span span = tracer.buildSpan("test_span").start();
-        span.log("Hello", null);
+        // Create an outer span to capture all activity
+        Span parentSpan = tracer.buildSpan("outer_span").start();
+        parentSpan.log("Starting outer span", null);
 
-        Span childSpan = tracer.buildSpan("test_child_span").withParent(span).withTag("hi", "bye").start();
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {}
+        // Create a simple child span
+        Span childSpan = tracer.buildSpan("hello_world")
+            .withParent(parentSpan)
+            .withTag("hello", "world")
+            .start();
+        Thread.sleep(100);
         childSpan.finish();
 
-        span.log("World!", null);
-        span.close();
+        // Spawn some concurrent threads - which in turn will spawn their
+        // own worker threads
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        for (int i = 0; i < 4; i++) {
+            executor.execute(new Thread() {
+                public void run() {
+                    try {
+                        spawnWorkers(tracer, parentSpan);
+                    } catch (InterruptedException e) {
+                        parentSpan.setTag("error", "true");
+                        parentSpan.log("InterruptedException", e);
+                    }
+                }
+            });
+        }
+        executor.shutdown();
+        executor.awaitTermination(20, TimeUnit.SECONDS);
 
-        JRETracer lsTracer = (JRETracer)tracer;
-        lsTracer.flush();
-
-        // TODO: this is a terrible hack to ensure the flush finishes before the
-        // process is interrupted
-        try {
-            Thread.sleep(2500);
-        } catch (InterruptedException e) {}
-
+        parentSpan.finish();
         System.out.println("Done!");
+    }
+
+    public static void spawnWorkers(Tracer tracer, Span outerSpan) throws InterruptedException  {
+        Span parentSpan = tracer.buildSpan("spawn_workers")
+            .withParent(outerSpan)
+            .start();
+
+        System.out.println("Launching worker threads.");
+
+        Thread workers[] = new Thread[4];
+        workers[0] = new Thread() {
+            public void run() {
+                Span childSpan = tracer.buildSpan("worker0")
+                    .withParent(parentSpan)
+                    .start();
+                for (int i = 0; i < 20; i++) {
+                    Span innerSpan = tracer.buildSpan("worker0/microspan")
+                        .withParent(childSpan)
+                        .start();
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException e) {
+                        childSpan.setTag("error", "true");
+                        childSpan.log("InterruptedException!", e);
+                    }
+                    innerSpan.finish();
+                }
+                childSpan.finish();
+            }
+        };
+        workers[1] = new Thread() {
+            public void run() {
+                Span childSpan = tracer.buildSpan("worker1")
+                    .withParent(parentSpan)
+                    .start();
+                for (int i = 0; i < 20; i++) {
+                    childSpan.log("Beginning inner loop", i);
+                    for (int j = 0; j < 10; j++) {
+                        try {
+                            Thread.sleep(1);
+                        } catch (InterruptedException e) {
+                            childSpan.setTag("error", "true");
+                            childSpan.log("InterruptedException!", e);
+                        }
+                    }
+                }
+                childSpan.finish();
+            }
+        };
+        workers[2] = new Thread() {
+            public void run() {
+                Span childSpan = tracer.buildSpan("worker2")
+                    .withParent(parentSpan)
+                    .start();
+                try {
+                    Thread.sleep(200);
+                } catch (InterruptedException e) {
+                    childSpan.setTag("error", "true");
+                    childSpan.log("InterruptedException!", e);
+                }
+                childSpan.finish();
+            }
+        };
+        workers[3] = new Thread() {
+            public void run() {
+                Span childSpan = tracer.buildSpan("worker3")
+                    .withParent(parentSpan)
+                    .start();
+                for (int i = 0; i < 20; i++) {
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException e) {
+                        childSpan.setTag("error", "true");
+                        childSpan.log("InterruptedException!", e);
+                    }
+                }
+                childSpan.finish();
+            }
+        };
+
+        for (int i = 0; i < 4; i++) {
+            workers[i].start();
+        }
+        for (int i = 0; i < 4; i++) {
+            workers[i].join();
+        }
+        System.out.println("Finished worker threads.");
+        parentSpan.finish();
     }
 }

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
@@ -19,27 +19,30 @@ public class JRETracer extends AbstractTracer {
 
     public JRETracer(Options options) {
         super(options);
+        this.addShutdownHook();
     }
 
     // Flush any data stored in the log and span buffers
     public void flush() {
         sendReport(true);
-        /*if (disabledTracer) return;
-
-        if (initializedTracer) {
-            if (debugReporter != null) {
-                debugFlush();
-            } else {
-                Connection connection = new Connection(this.serviceUrl);
-                connection.openConnection();
-                flushWorker(connection);
-                connection.closeConnection();
-            }
-        }*/
     }
 
     protected HashMap<String, String> retrieveDeviceInfo() {
         // TODO: Implement for Java Desktop Applications
         return null;
+    }
+
+    protected void addShutdownHook() {
+        final JRETracer self = this;
+        try {
+            Runtime.getRuntime().addShutdownHook(
+                new Thread() {
+                    public void run() {
+                        self.sendReport(true);
+                    }
+                }
+            );
+        } catch (Throwable t) {
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a final flush at runtime shutdown to the JRE client library. Adds some simple concurrency to the JRE example to exercise the code a bit more thoroughly.

The JRE example now produces a trace like this:

![image](https://cloud.githubusercontent.com/assets/432893/16705169/ff3bfd18-4536-11e6-9da6-364013930634.png)

Also updates the CircleCI make rule to ensure the example runs.
