### PR TITLE
Change/standardize tags

### DIFF
--- a/common/Makefile
+++ b/common/Makefile
@@ -1,4 +1,6 @@
-.PHONY: build thrift
+.PHONY: build thrift inc-version generate-version-source-file
+
+VERSION_SOURCE=src/main/java/com/lightstep/tracer/shared/Version.java
 
 build:
 	@echo "Nothing is built directly in this directory!"
@@ -8,6 +10,17 @@ build:
 inc-version:
 	awk 'BEGIN { FS = "." }; { printf("%d.%d.%d", $$1, $$2, $$3+1) }' VERSION > VERSION.incr
 	mv VERSION.incr VERSION
+	make generate-version-source-file
+
+generate-version-source-file:
+	@echo "Updating $(VERSION_SOURCE)"
+	@echo "// GENERATED FILE: DO NOT EDIT DIRECTLY\n\
+package com.lightstep.tracer.shared;\n\
+\n\
+public class Version {\n\
+  public static final String LIGHTSTEP_TRACER_VERSION = \"$(shell cat VERSION)\";\n\
+}\n\
+\n" > $(VERSION_SOURCE)
 
 # An internal LightStep target for regenerating the thrift protocol files
 thrift:

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -44,8 +44,11 @@ public abstract class AbstractTracer implements Tracer {
   private static final int DEFAULT_PLAINTEXT_PORT = 80;
   private static final String COLLECTOR_PATH = "/_rpc/v1/reports/binary";
 
-  public static final String COMPONENT_NAME_KEY = "component_name";
-  public static final String GUID_KEY = "guid";
+  public static final String LIGHTSTEP_TRACER_PLATFORM_KEY = "lightstep.tracer_platform";
+  public static final String LIGHTSTEP_TRACER_PLATFORM_VERSION_KEY = "lightstep.tracer_platform_version";
+  public static final String LIGHTSTEP_TRACER_VERSION_KEY = "lightstep.tracer_version";
+  public static final String COMPONENT_NAME_KEY = "lightstep.component_name";
+  public static final String GUID_KEY = "lightstep.guid";
 
   /**
    * The tag key used to define traces which are joined based on a GUID.
@@ -59,7 +62,7 @@ public abstract class AbstractTracer implements Tracer {
 
   // copied from options
   private final int maxBufferedSpans;
-  protected final int verbose;
+  protected final int verbosity;
 
   private final Auth auth;
   protected final Runtime runtime;
@@ -86,7 +89,7 @@ public abstract class AbstractTracer implements Tracer {
     this.spans = new ArrayList<SpanRecord>(maxBufferedSpans);
 
     this.clockState = new ClockState();
-    this.verbose = options.verbose;
+    this.verbosity = options.verbosity;
 
     this.auth = new Auth();
     auth.setAccess_token(options.accessToken);
@@ -111,7 +114,7 @@ public abstract class AbstractTracer implements Tracer {
     this.runtime = new Runtime();
     this.runtime.setStart_micros(System.currentTimeMillis() * 1000);
     for (Map.Entry<String, Object> entry : options.tags.entrySet()) {
-      this.runtime.addToAttrs(new KeyValue(entry.getKey(), entry.getValue().toString()));
+      this.addTracerTag(entry.getKey(), entry.getValue().toString());
     }
 
     String host = options.collectorHost != null ? options.collectorHost : DEFAULT_HOST;
@@ -328,6 +331,10 @@ public abstract class AbstractTracer implements Tracer {
     // Note that ThreadLocalRandom is a singleton, thread safe Random Generator
     long guid = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
     return Long.toHexString(guid);
+  }
+
+  protected void addTracerTag(String key, String value) {
+    this.runtime.addToAttrs(new KeyValue(key, value));
   }
 
   class SpanBuilder implements Tracer.SpanBuilder{

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -109,4 +109,9 @@ public class Options {
     this.maxReportingIntervalSeconds = maxReportingIntervalSeconds;
     return this;
   }
+
+  public Options withVerbosity(int verbosity) {
+    this.verbosity = verbosity;
+    return this;
+  }
 }

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -66,9 +66,15 @@ public class Options {
   /**
    * Controls the amount of local output produced by the tracer.  It does not
    * affect which spans are sent to the collector.  It is useful for
-   * diagnosing problems in the tracer itself.
+   * diagnosing problems in the tracer itself. The default value is 1.
+   *
+   * 0 - never produce local output
+   * 1 - only the first error encountered will be echoed locally
+   * 2 - all errors are echoed locally
+   * 3 - all errors, warnings, and info statements are echoed locally
+   * 4 - all internal log statements, including debugging details
    */
-  public int verbose;
+  public int verbosity;
 
   public Options(String accessToken) {
     this.accessToken = accessToken;

--- a/common/src/main/java/com/lightstep/tracer/shared/Version.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Version.java
@@ -1,0 +1,8 @@
+// GENERATED FILE: DO NOT EDIT DIRECTLY
+package com.lightstep.tracer.shared;
+
+public class Version {
+  public static final String LIGHTSTEP_TRACER_VERSION = "0.1.28";
+}
+
+

--- a/lightstep-tracer-jre/build.gradle
+++ b/lightstep-tracer-jre/build.gradle
@@ -40,7 +40,9 @@ sourceSets {
 }
 
 test {
-    testLogging.showStandardStreams = true
+    testLogging {
+        showStandardStreams = true
+    }
 }
 
 // Defines the repositories need for dependencies below
@@ -60,6 +62,10 @@ dependencies {
     compile 'org.json:json:20160212'
     compile 'javax.annotation:jsr250-api:1.0'
     testCompile 'junit:junit:4.11'
+}
+
+tasks.matching {it instanceof Test}.all {
+    testLogging.events = ["failed", "passed", "skipped"]
 }
 
 publishing {

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
@@ -1,7 +1,10 @@
 package com.lightstep.tracer.jre;
 
-import com.lightstep.tracer.shared.*;
 import java.util.HashMap;
+import java.util.Map;
+
+import com.lightstep.tracer.shared.*;
+import com.lightstep.tracer.thrift.KeyValue;
 
 public class JRETracer extends AbstractTracer {
 
@@ -19,6 +22,7 @@ public class JRETracer extends AbstractTracer {
 
     public JRETracer(Options options) {
         super(options);
+        this.addStandardTracerTags();
         this.addShutdownHook();
     }
 
@@ -30,6 +34,17 @@ public class JRETracer extends AbstractTracer {
     protected HashMap<String, String> retrieveDeviceInfo() {
         // TODO: Implement for Java Desktop Applications
         return null;
+    }
+
+    /**
+     * Adds standard tags set by all LightStep client libraries.
+     */
+    protected void addStandardTracerTags() {
+        // The platform is called "jre" rather than "Java" to clearly
+        // differentiate this library from the Android version
+        this.addTracerTag(LIGHTSTEP_TRACER_PLATFORM_KEY, "jre");
+        this.addTracerTag(LIGHTSTEP_TRACER_PLATFORM_VERSION_KEY, System.getProperty("java.version"));
+        this.addTracerTag(LIGHTSTEP_TRACER_VERSION_KEY, Version.LIGHTSTEP_TRACER_VERSION);
     }
 
     protected void addShutdownHook() {
@@ -44,5 +59,31 @@ public class JRETracer extends AbstractTracer {
             );
         } catch (Throwable t) {
         }
+    }
+
+    /**
+     * Internal class used primarily for unit testing and debugging. This is not
+     * part of the OpenTracing API and is not a supported API.
+     */
+    public class Status {
+        public Map<String, String> tags;
+
+        public Status() {
+            this.tags = new HashMap<String, String>();
+        }
+    }
+
+    /**
+     * Internal method used primarily for unit testing and debugging. This is not
+     * part of the OpenTracing API and is not a supported API.
+     */
+    public Status status() {
+        Status status = new Status();
+
+        for (KeyValue pair : this.runtime.getAttrs()) {
+            status.tags.put(pair.getKey(), pair.getValue());
+        }
+
+        return status;
     }
 }

--- a/lightstep-tracer-jre/src/test/java/com/lightstep/tracer/RuntimeTest.java
+++ b/lightstep-tracer-jre/src/test/java/com/lightstep/tracer/RuntimeTest.java
@@ -1,5 +1,8 @@
 package com.lightstep.tracer.jre;
 
+import java.io.PrintWriter;
+import java.util.Map;
+
 import io.opentracing.Tracer;
 import io.opentracing.Span;
 import com.lightstep.tracer.jre.JRETracer;
@@ -12,11 +15,20 @@ import org.junit.Test;
 
 public class RuntimeTest {
 
-    // Simple placeholder JUnit test
     @Test
-    public void sanityCheckTest() {
-        int result = 2 + 4;
-        assertEquals("Sanity check: 2 + 4 = 6", result, 6);
+    public void tracerHasStandardTags() throws Exception {
+        JRETracer tracer = new JRETracer(
+            new com.lightstep.tracer.shared.Options("{your_access_token}"));
+
+        JRETracer.Status status = tracer.status();
+
+        // Check standard tags
+        assertEquals(status.tags.containsKey("lightstep.component_name"), true);
+        assertEquals(status.tags.containsKey("lightstep.guid"), true);
+        assertEquals(status.tags.get("lightstep.tracer_platform"), "jre");
+        assertEquals(status.tags.containsKey("lightstep.tracer_platform_version"), true);
+        assertEquals(status.tags.containsKey("lightstep.tracer_version"), true);
+        assertEquals(status.tags.containsKey("lightstep.this_doesnt_exist"), false);
     }
 
     @Test

--- a/lightstep-tracer-jre/src/test/java/com/lightstep/tracer/RuntimeTest.java
+++ b/lightstep-tracer-jre/src/test/java/com/lightstep/tracer/RuntimeTest.java
@@ -32,6 +32,22 @@ public class RuntimeTest {
     }
 
     @Test
+    public void tracerOptionsAreSupported() {
+        // Ensure all the expected option methods are there and support
+        // chaining.
+        com.lightstep.tracer.shared.Options options =
+            new com.lightstep.tracer.shared.Options("{your_access_token}")
+                .withCollectorHost("localhost")
+                .withCollectorPort(4321)
+                .withCollectorEncryption(com.lightstep.tracer.shared.Options.Encryption.NONE)
+                .withVerbosity(2)
+                .withTag("my_tracer_tag", "zebra_stripes")
+                .withMaxReportingIntervalSeconds(30);
+
+        JRETracer tracer = new JRETracer(options);
+    }
+
+    @Test
     public void spanSetTagTest() {
         Tracer tracer = new JRETracer(
             new com.lightstep.tracer.shared.Options("{your_access_token}"));


### PR DESCRIPTION
## Summary

Fixes a number of small consistency issues with the Java library relative to other LightStep libraries:

* Report the platform information in a standard fashion
* Report the client library version in a standard fashion
* Rename `verbose` to `verbosity`
