### PR TITLE
Add a spans.dropped count to the Java client

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
@@ -1,0 +1,32 @@
+package com.lightstep.tracer.shared;
+
+import java.util.ArrayList;
+import com.lightstep.tracer.thrift.Metrics;
+import com.lightstep.tracer.thrift.MetricsSample;
+
+public class ClientMetrics {
+
+    // For capacity allocation purposes, keep this in sync with the number of
+    // counts actually being tracked.
+    private final int NUMBER_OF_COUNTS = 1;
+
+    public long spansDropped;
+
+    public ClientMetrics() {
+        this.spansDropped = 0;
+    }
+    
+    public ClientMetrics(ClientMetrics that) {
+        this.spansDropped = that.spansDropped;
+    }
+
+    public void merge(ClientMetrics that) {
+        this.spansDropped += that.spansDropped;
+    }
+
+    public Metrics toThrift() {
+        ArrayList<MetricsSample> counts = new ArrayList<MetricsSample>(NUMBER_OF_COUNTS);
+        counts.add(new MetricsSample("spans.dropped").setInt64_value(spansDropped));
+        return new Metrics().setCounts(counts);
+    }
+}

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -53,9 +53,12 @@ public class Options {
   public Map<String, Object> tags = new HashMap<String, Object>();
 
   /**
-   * @deprecated will be replaced by a throughput-based limit on resource use
+   * UNSUPPORTED API: intended for unit testing purposes only and should
+   * not be used in production code.
+   *
+   * Production control of limits will be via a throughput-based limit on
+   * resource use.
    */
-  @Deprecated
   public int maxBufferedSpans;
 
   /**
@@ -112,6 +115,14 @@ public class Options {
 
   public Options withVerbosity(int verbosity) {
     this.verbosity = verbosity;
+    return this;
+  }
+
+  /**
+   * UNSUPPORTED API: intended for unit testing purposes only.
+   */
+  public Options withMaxBufferedSpans(int max) {
+    this.maxBufferedSpans = max;
     return this;
   }
 }

--- a/lightstep-tracer-jre/build.gradle
+++ b/lightstep-tracer-jre/build.gradle
@@ -39,12 +39,6 @@ sourceSets {
     }
 }
 
-test {
-    testLogging {
-        showStandardStreams = true
-    }
-}
-
 // Defines the repositories need for dependencies below
 repositories {
     jcenter()
@@ -65,7 +59,11 @@ dependencies {
 }
 
 tasks.matching {it instanceof Test}.all {
-    testLogging.events = ["failed", "passed", "skipped"]
+    testLogging {
+        events 'passed', 'skipped', 'failed', 'standardOut', 'standardError'
+        outputs.upToDateWhen { false }
+        showStandardStreams = true
+    }
 }
 
 publishing {

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
@@ -60,30 +60,4 @@ public class JRETracer extends AbstractTracer {
         } catch (Throwable t) {
         }
     }
-
-    /**
-     * Internal class used primarily for unit testing and debugging. This is not
-     * part of the OpenTracing API and is not a supported API.
-     */
-    public class Status {
-        public Map<String, String> tags;
-
-        public Status() {
-            this.tags = new HashMap<String, String>();
-        }
-    }
-
-    /**
-     * Internal method used primarily for unit testing and debugging. This is not
-     * part of the OpenTracing API and is not a supported API.
-     */
-    public Status status() {
-        Status status = new Status();
-
-        for (KeyValue pair : this.runtime.getAttrs()) {
-            status.tags.put(pair.getKey(), pair.getValue());
-        }
-
-        return status;
-    }
 }

--- a/lightstep-tracer-jre/src/test/java/com/lightstep/tracer/RuntimeTest.java
+++ b/lightstep-tracer-jre/src/test/java/com/lightstep/tracer/RuntimeTest.java
@@ -1,5 +1,7 @@
 package com.lightstep.tracer.jre;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.io.PrintWriter;
 import java.util.Map;
 
@@ -71,6 +73,28 @@ public class RuntimeTest {
         span.finish();
 
         this.assertSpanHasTag(span, "my_key", "my_value");
+    }
+
+    @Test
+    public void spansDroppedCounterTest() {
+        JRETracer tracer = new JRETracer(
+            new com.lightstep.tracer.shared.Options("{your_access_token}")
+                .withMaxBufferedSpans(10));
+
+        JRETracer.Status status = tracer.status();
+        assertEquals(status.clientMetrics.spansDropped, 0);
+        for (int i = 0; i < 10; i++) {
+            Span span = tracer.buildSpan("test_span").start();
+            span.finish();
+        }
+        status = tracer.status();
+        assertEquals(status.clientMetrics.spansDropped, 0);
+        for (int i = 0; i < 10; i++) {
+            Span span = tracer.buildSpan("test_span").start();
+            span.finish();
+        }
+        status = tracer.status();
+        assertEquals(status.clientMetrics.spansDropped, 10);
     }
 
     protected void assertSpanHasTag(Span span, String key, String value) {


### PR DESCRIPTION
## Summary

* Client library now reports the `internal_metrics` field to the collector
* Implements the `spans.dropped` counter (only metric currently)
* Add a very basic unit test to test the above
* Fixes a NullPointerException that could occur when the client was in a disabled state
