### PR TITLE
Changes/internal logs

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -1,5 +1,7 @@
 package com.lightstep.tracer.shared;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -12,6 +14,10 @@ import java.util.StringTokenizer;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.thrift.TException;
 import org.apache.thrift.TApplicationException;
@@ -34,7 +40,7 @@ import io.opentracing.Tracer;
 
 public abstract class AbstractTracer implements Tracer {
   // Delay before sending the initial report
-  private static final long REPORTING_DELAY_MILLIS = 0;
+  private static final long REPORTING_DELAY_MILLIS = 20;
   // Maximum interval between reports
   private static final long DEFAULT_REPORTING_INTERVAL_MILLIS = 2500;
   private static final int DEFAULT_MAX_BUFFERED_SPANS = 1000;
@@ -80,25 +86,69 @@ public abstract class AbstractTracer implements Tracer {
   protected final Runtime runtime;
   private URL collectorURL;
 
+
   protected ArrayList<SpanRecord> spans;
   protected ClockState clockState;
   protected ClientMetrics clientMetrics;
 
   // Should *NOT* attempt to take a span's lock while holding this lock.
   protected final Object mutex = new Object();
-  private final Timer timer;
   private boolean reportInProgress;
+  private AtomicBoolean hasUnreportSpans;
+  private final Timer timer;
+  private final ThreadPoolExecutor executor;
   protected boolean isDisabled;
 
   protected TTransport transport;
   protected ReportingService.Client client;
 
   public AbstractTracer(Options options) {
+
+    // A description of the background flush / threading setup:
+    //
+    // First off, the current background flush setup can likely be simplified.
+    // There are three interacting parts, which seems overly complicated for what
+    // needs to be done (especially given that Android has specific API for background
+    // network calls). Regardless, on to the details...
+    //
+    // TIMER: the AbstractTracer creates a *daemon* timer which fires at a regular
+    // interval to trigger background flush. This is good because the daemon timer
+    // does not prevent the JVM from shutting down (otherwise, the client library
+    // would require an explicit shutdown() call from the consumer of the library).
+    // The downside, is the daemon threads are killed with no chance to clean-up
+    // which means if the sendReport implementation is invoked from the daemon
+    // thread it may be killed and leave the Tracer in a bad state - which prevents
+    // the Tracer from doing a final, at-shutdown flush.
+    //
+    // EXECUTOR: to resolve this, the timer, instead of doing the work itself,
+    // runs the flush in a ThreadPoolExecutor that won't get killed arbitrarily.
+    // The thread pool itself will keep the JVM from shutting down (thus the
+    // point of a daemon timer in the first place), so the thread pool is given
+    // a keep-alive time where the thread is released if there's no work for the
+    // pool.  Thus the JVM is held up for a max of the keep-alive time. (Also,
+    // if the time out happens in normal operation, the pool automatically will
+    // recreate the thread if new tasks come in.)
+    //
+    // ATOMIC BOOLEAN: lastly there's an AtomicBoolean that gets set every time
+    // the Tracer gets a new span. This allows the timer to avoid putting new
+    // tasks into the executor when there's no work to be done (and thus
+    // constantly refreshing the keep-alive, preventing a clean shutdown). It's
+    // an atomic bool so the daemon thread doesn't have to touch the Tracer's
+    // mutex and potentially leave that in a bad state if killed.
+    //
+    // This executor setup comes from:
+    // http://stackoverflow.com/questions/13883293/turning-an-executorservice-to-daemon-in-java
+    //
+    // TODO: the timer should have some jitter in the interval
     this.timer = new Timer(true);
+    this.executor = new ThreadPoolExecutor(1, 1, 2 * DEFAULT_REPORTING_INTERVAL_MILLIS, MILLISECONDS,
+      new java.util.concurrent.LinkedBlockingQueue<Runnable>());
+    this.executor.allowCoreThreadTimeOut(true);
 
     // TODO sanity check options
     this.maxBufferedSpans = options.maxBufferedSpans > 0 ?
       options.maxBufferedSpans : DEFAULT_MAX_BUFFERED_SPANS;
+    this.hasUnreportSpans = new AtomicBoolean(false);
     this.spans = new ArrayList<SpanRecord>(maxBufferedSpans);
 
     this.clockState = new ClockState();
@@ -155,7 +205,14 @@ public abstract class AbstractTracer implements Tracer {
     this.debug("Starting reporting timer.");
     long interval = options.maxReportingIntervalSeconds > 0 ?
       options.maxReportingIntervalSeconds * 1000 : DEFAULT_REPORTING_INTERVAL_MILLIS;
-    timer.schedule(new Flush(), REPORTING_DELAY_MILLIS, interval);
+    timer.schedule(new FlushTimer(), REPORTING_DELAY_MILLIS, interval);
+
+    java.lang.Runtime.getRuntime().addShutdownHook(new Thread() {
+       public void run() {
+         AbstractTracer.this.debug("Running shutdown hook");
+         AbstractTracer.this.shutdown();
+       }
+    });
   }
 
   public String getAccessToken() {
@@ -165,13 +222,44 @@ public abstract class AbstractTracer implements Tracer {
   }
 
   /**
+   * Extends TimerTask to call flush().
+   */
+  class FlushRunnable implements Runnable {
+    @Override
+    public void run() {
+      AbstractTracer.this.debug("Flush runnable start.");
+      AbstractTracer.this.flush();
+      AbstractTracer.this.debug("Flush runnable end.");
+    }
+  }
+
+  /**
+   * Extends TimerTask to call flush().
+   */
+  class FlushTimer extends TimerTask {
+    @Override
+    public void run() {
+      if (!AbstractTracer.this.hasUnreportSpans.get()) {
+        return;
+      }
+      AbstractTracer.this.executor.execute(new FlushRunnable());
+    }
+  }
+
+  /**
    * Gracefully stops the tracer.
+   *
+   * NOTE: this can optionally be called by the consumer of the library and,
+   * if the consumer has not alreayd called it, *must* be called internally by
+   * the library to cancel the timer.
    */
   public void shutdown() {
     if (isDisabled) {
       return;
     }
 
+    this.debug("shutdown() called");
+    this.timer.cancel();
     flush();
     disable();
   }
@@ -181,7 +269,7 @@ public abstract class AbstractTracer implements Tracer {
    * subsequent method invocations into no-ops.
    */
   public void disable() {
-    this.warn("Disabling client library");
+    this.info("Disabling client library");
     synchronized (this.mutex) {
       this.timer.cancel();
       this.timer.purge();
@@ -225,16 +313,6 @@ public abstract class AbstractTracer implements Tracer {
    * network calls.
    */
   public abstract void flush();
-
-  /**
-   * Extends TimerTask to call flush().
-   */
-  class Flush extends TimerTask {
-    @Override
-    public void run() {
-      AbstractTracer.this.flush();
-    }
-  }
 
   /**
    * Does the work of a flush by sending spans to the collector.
@@ -319,8 +397,11 @@ public abstract class AbstractTracer implements Tracer {
     }
 
     try {
+      this.debug("Sending report");
       long originMicros = System.currentTimeMillis() * 1000;
       ReportResponse resp = this.client.Report(this.auth, req);
+      this.hasUnreportSpans.set(false);
+      this.debug("Report sent");
 
       if (resp.isSetTiming()) {
         this.clockState.addSample(originMicros,
@@ -369,6 +450,7 @@ public abstract class AbstractTracer implements Tracer {
       if (this.spans.size() >= this.maxBufferedSpans) {
         this.clientMetrics.spansDropped++;
       } else {
+        this.hasUnreportSpans.set(true);
         this.spans.add(span);
       }
     }

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -435,11 +435,21 @@ public abstract class AbstractTracer implements Tracer {
   /**
    * Internal logging.
    */
-  protected void infoV(int level, String msg, Object payload) {
-    if (level < this.verbosity) {
+  protected void debug(String msg, Object payload) {
+    if (this.verbosity < 4) {
         return;
     }
-    this.printLogToConsole("[LightStep:INFOV" + level + "] " + msg, payload);
+    this.printLogToConsole("[LightStep:DEBUG] " + msg, payload);
+  }
+
+  /**
+   * Internal logging.
+   */
+  protected void info(String msg, Object payload) {
+    if (this.verbosity < 3) {
+        return;
+    }
+    this.printLogToConsole("[LightStep:INFO] " + msg, payload);
   }
 
   /**

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -51,6 +51,17 @@ public abstract class AbstractTracer implements Tracer {
   public static final String GUID_KEY = "lightstep.guid";
 
   /**
+   * For mapping internal logs to Android log levels without importing Android
+   * pacakges.
+   */
+  protected enum InternalLogLevel {
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR
+  }
+
+  /**
    * The tag key used to define traces which are joined based on a GUID.
    */
 	public static final String TRACE_GUID_KEY = "join:trace_guid";
@@ -467,7 +478,7 @@ public abstract class AbstractTracer implements Tracer {
     if (this.verbosity < 4) {
         return;
     }
-    this.printLogToConsole("[LightStep:DEBUG] " + msg, payload);
+    this.printLogToConsole(InternalLogLevel.DEBUG, msg, payload);
   }
 
   /**
@@ -484,7 +495,7 @@ public abstract class AbstractTracer implements Tracer {
     if (this.verbosity < 3) {
         return;
     }
-    this.printLogToConsole("[LightStep:INFO] " + msg, payload);
+    this.printLogToConsole(InternalLogLevel.INFO, msg, payload);
   }
 
   /**
@@ -501,7 +512,7 @@ public abstract class AbstractTracer implements Tracer {
     if (this.verbosity < 3) {
         return;
     }
-    this.printLogToConsole("[LightStep:WARN] " + msg, payload);
+    this.printLogToConsole(InternalLogLevel.WARN, msg, payload);
   }
 
   /**
@@ -522,12 +533,10 @@ public abstract class AbstractTracer implements Tracer {
       return;
     }
     this.visibleErrorCount++;
-    this.printLogToConsole("[LightStep:ERROR] " + msg, payload);
+    this.printLogToConsole(InternalLogLevel.ERROR, msg, payload);
   }
 
-  protected void printLogToConsole(String msg, Object payload) {
-    // TODO: make this abstract and implement in JRE & Android
-  }
+  protected abstract void printLogToConsole(InternalLogLevel level, String msg, Object payload);
 
   /**
    * Internal class used primarily for unit testing and debugging. This is not

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -172,12 +172,16 @@ public abstract class AbstractTracer implements Tracer {
       }
     }
 
+    String guid;
     if (options.tags.get(GUID_KEY) == null) {
-      String guid = generateGUID();
+      guid = generateGUID();
       options.tags.put(GUID_KEY, guid);
+    } else {
+      guid = options.tags.get(GUID_KEY).toString();
     }
 
     this.runtime = new Runtime();
+    this.runtime.setGuid(guid);
     this.runtime.setStart_micros(System.currentTimeMillis() * 1000);
     for (Map.Entry<String, Object> entry : options.tags.entrySet()) {
       this.addTracerTag(entry.getKey(), entry.getValue().toString());

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -81,6 +81,7 @@ public class Options {
 
   public Options(String accessToken) {
     this.accessToken = accessToken;
+    this.verbosity = 1;
   }
 
   public Options withAccessToken(String accessToken) {

--- a/common/src/main/java/com/lightstep/tracer/shared/Span.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Span.java
@@ -124,7 +124,7 @@ public class Span implements io.opentracing.Span {
           log.setPayload_json(payloadString);
         } catch (JsonProcessingException e) {
           // Just use a string.
-          // TODO and/or log this somewhere?
+          this.tracer.debug("Payload not serializable to JSON. Setting as String. (Span GUID=" + this.getGUID() + ")");
           log.setPayload_json(payload.toString());
         }
       }

--- a/examples/jre-simple/src/main/java/Simple.java
+++ b/examples/jre-simple/src/main/java/Simple.java
@@ -14,6 +14,7 @@ public class Simple {
 
         final Tracer tracer = new com.lightstep.tracer.jre.JRETracer(
             new com.lightstep.tracer.shared.Options("{your_access_token}")
+                .withVerbosity(4)
         );
 
         // Create an outer span to capture all activity

--- a/lightstep-tracer-android/src/main/java/com/lightstep/tracer/android/Tracer.java
+++ b/lightstep-tracer-android/src/main/java/com/lightstep/tracer/android/Tracer.java
@@ -13,6 +13,8 @@ import com.lightstep.tracer.thrift.KeyValue;
 public class Tracer extends AbstractTracer {
   private final Context ctx;
 
+  private static final String TAG = "Tracer";
+
   /**
    * Create a new tracer that will send spans to a LightStep collector.
    *
@@ -65,6 +67,30 @@ public class Tracer extends AbstractTracer {
     protected Void doInBackground(Void ...voids) {
       sendReport(false);
       return null;
+    }
+  }
+
+  protected void printLogToConsole(InternalLogLevel level, String msg, Object payload) {
+    String s = msg;
+    if (payload != null) {
+        s += " " + payload.toString();
+    }
+    switch (level) {
+    case DEBUG:
+        Log.d(TAG, s);
+        break;
+    case INFO:
+        Log.i(TAG, s);
+        break;
+    case WARN:
+        Log.w(TAG, s);
+        break;
+    case ERROR:
+        Log.e(TAG, s);
+        break;
+    default:
+        Log.e(TAG, s);
+        break;
     }
   }
 

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
@@ -31,8 +31,26 @@ public class JRETracer extends AbstractTracer {
         sendReport(true);
     }
 
-    protected void printLogToConsole(String msg, Object payload) {
-        String s = msg;
+    protected void printLogToConsole(InternalLogLevel level, String msg, Object payload) {
+        String s;
+        switch (level) {
+        case DEBUG:
+            s = "[Lightstep:DEBUG] ";
+            break;
+        case INFO:
+            s = "[Lightstep:INFO] ";
+            break;
+        case WARN:
+            s = "[Lightstep:WARN] ";
+            break;
+        case ERROR:
+            s = "[Lightstep:ERROR] ";
+            break;
+        default:
+            s = "[Lightstep:???] ";
+            break;
+        }
+        s += msg;
         if (payload != null) {
             s += " " + payload.toString();
         }

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
@@ -23,7 +23,6 @@ public class JRETracer extends AbstractTracer {
     public JRETracer(Options options) {
         super(options);
         this.addStandardTracerTags();
-        this.addShutdownHook();
     }
 
     // Flush any data stored in the log and span buffers
@@ -71,20 +70,5 @@ public class JRETracer extends AbstractTracer {
         this.addTracerTag(LIGHTSTEP_TRACER_PLATFORM_KEY, "jre");
         this.addTracerTag(LIGHTSTEP_TRACER_PLATFORM_VERSION_KEY, System.getProperty("java.version"));
         this.addTracerTag(LIGHTSTEP_TRACER_VERSION_KEY, Version.LIGHTSTEP_TRACER_VERSION);
-    }
-
-    protected void addShutdownHook() {
-        final JRETracer self = this;
-        try {
-            Runtime.getRuntime().addShutdownHook(
-                new Thread() {
-                    public void run() {
-                        self.debug("Sending final report at shutdown");
-                        self.sendReport(true);
-                    }
-                }
-            );
-        } catch (Throwable t) {
-        }
     }
 }

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
@@ -31,6 +31,14 @@ public class JRETracer extends AbstractTracer {
         sendReport(true);
     }
 
+    protected void printLogToConsole(String msg, Object payload) {
+        String s = msg;
+        if (payload != null) {
+            s += " " + payload.toString();
+        }
+        System.err.println(s);
+    }
+
     protected HashMap<String, String> retrieveDeviceInfo() {
         // TODO: Implement for Java Desktop Applications
         return null;
@@ -53,6 +61,7 @@ public class JRETracer extends AbstractTracer {
             Runtime.getRuntime().addShutdownHook(
                 new Thread() {
                     public void run() {
+                        self.debug("Sending final report at shutdown");
                         self.sendReport(true);
                     }
                 }


### PR DESCRIPTION
## Summary

Two parts to this pull request: 

- Adds internal logs to the client library and second, as a result of that
- Fixes threading problems that were revealed once internal error logging was enabled

The logging is fairly straightforward. Error, warn, info, and debug logs map to their Android equivalents and print to System.err on the JRE (provided the verbosity option is set to allow such). 

The threading issue in short was this: the background reporting was run in a timer *daemon* thread, one that get be killed at any arbitrary point during shutdown with no chance for clean-up. This left the tracer in a unknown state, often making it impossible to do a final report upon exit. The fix is detailed a fairly thorough comment in `AbstractTracer.java`.  There were also some thread-safety issues in the `ClockState` class that were easily addressed by adding a lock to the class.

Other minor changes:

- The verbosity option was not set to the right default
- The `sendReport()` function could leave `reportInProgress` in an incorrect state if it early returned; this has been fixed. This was a fairly serious defect as it prevented future reports from being sent
- The JRE example now sets the verbosity to 4 as its more instructive as an example
- The JRE was doing a duplicate final flush; this wasn't noticed previously due to the threading issue, but now has been removed



