### PR TITLE
Fix empty reports

### DIFF
--- a/examples/android-demo/app/build.gradle
+++ b/examples/android-demo/app/build.gradle
@@ -17,8 +17,10 @@ android {
 
     sourceSets {
         main.java.srcDirs = [
+                // vvv INCLUDE FOR BUILDS FROM LOCAL SOURCE
                 '../../../common/src/main/java',
                 '../../../lightstep-tracer-android/src/main/java',
+                // ^^^ INCLUDE FOR BUILDS FROM LOCAL SOURCE
                 'src/main/java'
         ]
     }
@@ -57,15 +59,16 @@ dependencies {
     compile 'com.android.volley:volley:1.0.0'
     compile 'io.opentracing:opentracing-api:0.9.1'
 
+    // vvv INCLUDE FOR BUILDS FROM LOCAL SOURCE
     compile('org.apache.thrift:libthrift:0.9.2') {
         // Not needed on Android
         exclude module: 'httpclient'
     }
     compile 'com.fasterxml.jackson.core:jackson-databind:2.7.3'
     compile 'javax.annotation:jsr250-api:1.0'
+    // ^^^ INCLUDE FOR BUILDS FROM LOCAL SOURCE
 
-    // Toggle the below to use the code in the source tree rather than the
-    // published version
+    // vvv INCLUDE FOR BUILDS AGAINST PUBLISHED AAR
     //compile 'com.lightstep.tracer:lightstep-tracer-android:' + current_version
-    //compile(name:'lightstep-tracer-android-release', ext:'aar')
+    // ^^^ INCLUDE FOR BUILDS AGAINST PUBLISHED AAR
 }

--- a/examples/android-demo/app/build.gradle
+++ b/examples/android-demo/app/build.gradle
@@ -14,6 +14,15 @@ android {
         versionCode 1
         versionName "1.0"
     }
+
+    sourceSets {
+        main.java.srcDirs = [
+                '../../../common/src/main/java',
+                '../../../lightstep-tracer-android/src/main/java',
+                'src/main/java'
+        ]
+    }
+
     buildTypes {
         release {
             minifyEnabled false
@@ -34,11 +43,10 @@ android {
 repositories {
     jcenter()
     maven {
-        url  "http://dl.bintray.com/lightstep/maven"
-        url  "http://oss.jfrog.org/oss-snapshot-local/"
+        url "http://dl.bintray.com/lightstep/maven"
     }
-    flatDir {
-        dirs '../../../lightstep-tracer-android/build/outputs/aar'
+    maven {
+        url  "http://oss.jfrog.org/oss-snapshot-local/"
     }
 }
 
@@ -49,8 +57,15 @@ dependencies {
     compile 'com.android.volley:volley:1.0.0'
     compile 'io.opentracing:opentracing-api:0.9.1'
 
+    compile('org.apache.thrift:libthrift:0.9.2') {
+        // Not needed on Android
+        exclude module: 'httpclient'
+    }
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.3'
+    compile 'javax.annotation:jsr250-api:1.0'
+
     // Toggle the below to use the code in the source tree rather than the
     // published version
-    compile 'com.lightstep.tracer:lightstep-tracer-android:' + current_version
+    //compile 'com.lightstep.tracer:lightstep-tracer-android:' + current_version
     //compile(name:'lightstep-tracer-android-release', ext:'aar')
 }

--- a/examples/android-demo/app/src/main/java/com/lightstep/samples/sampleapp/MainActivityFragment.java
+++ b/examples/android-demo/app/src/main/java/com/lightstep/samples/sampleapp/MainActivityFragment.java
@@ -54,7 +54,7 @@ public class MainActivityFragment extends Fragment {
     // Initialize tracer
     this.tracer = new com.lightstep.tracer.android.Tracer(
             getContext(),
-            new Options("{your_access_token}"));
+            new Options("{your_access_token}").withVerbosity(4));
     Log.d(TAG, "Tracer successfully initialized!");
 
     View fragmentView = (View) inflater.inflate(R.layout.fragment_main, container, false);


### PR DESCRIPTION
## Summary

Fixes a defect where the reporting timer was not considering the empty reports that the clock state priming sends to the server. The timer did not issue reports when their were no spans to report, so it was never sending these reports.

Also:

* Build the `android-demo` from the local source rather than the publish artifact by default
* Fix a typo in the `hasUnreportedSpans` variable name
* Add a few more internal logging statements to make debugging easier
