### PR TITLE
Add withComponentName method to Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ import io.opentracing.Tracer;
 
 protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    
+
     // Initialize LightStep tracer implementation in the main activity
     // (or anywhere with a valid android.content.Context).
     this.tracer = new com.lightstep.tracer.android.Tracer(
          this,
          new com.lightstep.tracer.shared.Options("{your_access_token}"));
     ...
-    
+
     // Start and finish a Span
     Span span = this.tracer.buildSpan("hello_span").start();
     this.doSomeWorkHere();
@@ -87,11 +87,11 @@ dependencies {
 
 ### Setting a custom component name
 
-To set the ame used in the LightStep UI for this instance of the Tracer, set the `"lightstep.component_name"` tag as part of the initialization options:
+To set the name used in the LightStep UI for this instance of the Tracer, call `withComponentName()` on the `Options` object:
 
 ```
 options = new com.lightstep.tracer.shared.Options("{your_access_token}")
-    .withTag("lightstep.component_name", "your_custom_name");
+    .withComponentName("your_custom_name");
 ```
 
 

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -104,6 +104,10 @@ public class Options {
     return this;
   }
 
+  public Options withComponentName(String name) {
+    return this.withTag(AbstractTracer.COMPONENT_NAME_KEY, name);
+  }
+
   public Options withTag(String key, Object value) {
     this.tags.put(key, value);
     return this;

--- a/lightstep-tracer-jre/src/test/java/com/lightstep/tracer/RuntimeTest.java
+++ b/lightstep-tracer-jre/src/test/java/com/lightstep/tracer/RuntimeTest.java
@@ -34,6 +34,16 @@ public class RuntimeTest {
     }
 
     @Test
+    public void tracerSupportsWithComponentName() throws Exception {
+        JRETracer tracer = new JRETracer(
+            new com.lightstep.tracer.shared.Options("{your_access_token}")
+                .withComponentName("my_component"));
+
+        JRETracer.Status status = tracer.status();
+        assertEquals(status.tags.get("lightstep.component_name"), "my_component");
+    }
+
+    @Test
     public void tracerOptionsAreSupported() {
         // Ensure all the expected option methods are there and support
         // chaining.


### PR DESCRIPTION
## Summary

Adds a `Options.withComponentName()` method for setting custom component names (the name is pulled from the package name by default).

* Updates the README docs
* Adds a trivial unit test.