### PR TITLE
Fix OpenTracing version number

### DIFF
--- a/examples/android-demo/app/build.gradle
+++ b/examples/android-demo/app/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     compile 'com.android.support:appcompat-v7:23.0.0'
     compile 'com.android.support:design:22.2.0'
     compile 'com.android.volley:volley:1.0.0'
-    compile 'io.opentracing:opentracing-api:0.9.1'
+    compile 'io.opentracing:opentracing-api:0.10.0'
 
     // vvv INCLUDE FOR BUILDS FROM LOCAL SOURCE
     compile('org.apache.thrift:libthrift:0.9.2') {


### PR DESCRIPTION
## Summary

Fixes the Android demo app. It builds from the repo's local source (not the published artifact) and therefore needs to have its dependency versions kept in sync with the library.