### PR TITLE
Improve reporting loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,24 @@ options = new com.lightstep.tracer.shared.Options("{your_access_token}")
     .withComponentName("your_custom_name");
 ```
 
+### Disabling the reporting loop
+
+By default, the Java library does a report of any buffered data on a fairly regular interval. To disable this behavior and rely only on explicit calls to `flush()` to report data, initialize with:
+
+```
+options = new com.lightstep.tracer.shared.Options("{your_access_token}")
+    .withDisableReportingLoop(true);
+```
+
+### Disabling the report at exit
+
+By default, the library will send a final report of any remaining buffered data at process exit. To disable this behavior, set the following option:
+
+```
+options = new com.lightstep.tracer.shared.Options("{your_access_token}")
+    .withDisableReportAtExit(true);
+```
+
 ## Development info
 
 See [DEV.md](DEV.md) for information on contributing to this instrumentation library.

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -512,7 +512,7 @@ public abstract class AbstractTracer implements Tracer {
       for (SpanRecord span : req.span_records) {
         addSpan(span);
       }
-      return true;
+      return false;
     }
   }
 

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -42,7 +42,6 @@ public abstract class AbstractTracer implements Tracer {
   private static final long REPORTING_DELAY_MILLIS = 20;
   // Maximum interval between reports
   private static final long DEFAULT_CLOCK_STATE_INTERVAL_MILLIS = 500;
-  private static final long DEFAULT_REPORTING_INTERVAL_MILLIS = 2500;
   private static final int DEFAULT_MAX_BUFFERED_SPANS = 1000;
   private static final int DEFAULT_REPORT_TIMEOUT_MILLIS = 10 * 1000;
 
@@ -192,6 +191,8 @@ public abstract class AbstractTracer implements Tracer {
     }
   }
 
+  protected abstract long getDefaultReportingIntervalMillis();
+
   class ReportingLoop implements Runnable {
     // Controls how often the reporting loop itself checks if there's any work to do: this is
     // *not* the reporting interval itself! This should be kept relatively short as
@@ -207,7 +208,7 @@ public abstract class AbstractTracer implements Tracer {
     ReportingLoop(Options options) {
       this.reportingIntervalMillis = options.maxReportingIntervalSeconds > 0 ?
               options.maxReportingIntervalSeconds * 1000 :
-              AbstractTracer.this.DEFAULT_REPORTING_INTERVAL_MILLIS;
+              AbstractTracer.this.getDefaultReportingIntervalMillis();
     }
 
     @Override

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -221,9 +221,6 @@ public abstract class AbstractTracer implements Tracer {
           // Check if it's time for the next report
           long nowMillis = System.currentTimeMillis();
           if (nowMillis >= nextReportMillis) {
-            // TODO: nextReportMillis should be computed once the flush has succeeded or
-            // failed. flush() is currently an async call that has no signal as to when
-            // it completes.
             SimpleFuture<Boolean> result = AbstractTracer.this.flushInternal();
             boolean reportSucceeded = false;
             try {

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -290,7 +290,9 @@ public abstract class AbstractTracer implements Tracer {
     }
 
     this.debug("shutdown() called");
-    this.reportingLoop.stop();
+    if (this.reportingLoop != null) {
+      this.reportingLoop.stop();
+    }
     flush();
     disable();
   }
@@ -302,7 +304,9 @@ public abstract class AbstractTracer implements Tracer {
   public void disable() {
     this.info("Disabling client library");
     synchronized (this.mutex) {
-      this.reportingLoop.stop();
+      if (this.reportingLoop != null) {
+        this.reportingLoop.stop();
+      }
 
       if (this.transport != null) {
         this.transport.close();

--- a/common/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
@@ -21,6 +21,9 @@ public class ClientMetrics {
     }
 
     public void merge(ClientMetrics that) {
+        if (that == null) {
+            return;
+        }
         this.spansDropped += that.spansDropped;
     }
 

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -79,9 +79,22 @@ public class Options {
    */
   public int verbosity;
 
+  /**
+   * If true, the background reporting loop will be disabled. Reports will
+   * only occur on explicit calls to Flush();
+   */
+  public boolean disableReportingLoop;
+
+  /**
+   * If true, the library will *not* attempt an automatic report at process exit.
+   */
+  public boolean disableReportOnExit;
+
   public Options(String accessToken) {
     this.accessToken = accessToken;
     this.verbosity = 1;
+    this.disableReportingLoop = false;
+    this.disableReportOnExit = false;
   }
 
   public Options withAccessToken(String accessToken) {
@@ -120,6 +133,16 @@ public class Options {
 
   public Options withVerbosity(int verbosity) {
     this.verbosity = verbosity;
+    return this;
+  }
+
+  public Options withDisableReportingLoop(boolean disable) {
+    this.disableReportingLoop = true;
+    return this;
+  }
+
+  public Options withDisableReportOnExit(boolean disable) {
+    this.disableReportOnExit = true;
     return this;
   }
 

--- a/common/src/main/java/com/lightstep/tracer/shared/SimpleFuture.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SimpleFuture.java
@@ -1,5 +1,13 @@
 package com.lightstep.tracer.shared;
 
+/**
+ * Simple Future/Promise-like class.
+ *
+ * Acts as a simple wrapper on Object wait() / notify() - avoiding the
+ * complex future interfaces in Java 7/8.
+ *
+ * @param <T>
+ */
 public class SimpleFuture<T> {
     private boolean resolved;
     private T value;

--- a/common/src/main/java/com/lightstep/tracer/shared/SimpleFuture.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SimpleFuture.java
@@ -1,0 +1,40 @@
+package com.lightstep.tracer.shared;
+
+public class SimpleFuture<T> {
+    private boolean resolved;
+    private T value;
+
+    public SimpleFuture() {
+        this.resolved = false;
+    }
+    public SimpleFuture(T value) {
+        this.value = value;
+        this.resolved = true;
+    }
+
+    public void set(T value) {
+        synchronized(this) {
+            this.value = value;
+            this.resolved = true;
+            this.notifyAll();
+        }
+    }
+
+    public T get() throws InterruptedException {
+        if (!resolved) {
+            synchronized(this) {
+                this.wait();
+            }
+        }
+        return this.value;
+    }
+
+    public T getWithTimeout(long millis) throws InterruptedException {
+        if (!resolved) {
+            synchronized(this) {
+                this.wait(millis);
+            }
+        }
+        return this.value;
+    }
+}

--- a/examples/android-demo/app/src/main/java/com/lightstep/samples/sampleapp/MainActivityFragment.java
+++ b/examples/android-demo/app/src/main/java/com/lightstep/samples/sampleapp/MainActivityFragment.java
@@ -13,6 +13,7 @@ import android.widget.EditText;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
@@ -266,6 +267,7 @@ public class MainActivityFragment extends Fragment {
                   errorListener.onErrorResponse(error);
                 }
               });
+      this.setRetryPolicy(new DefaultRetryPolicy(3000, 2, 1.0f));
       this.span = (com.lightstep.tracer.shared.Span)span;
     }
 

--- a/lightstep-tracer-android/src/main/java/com/lightstep/tracer/android/Tracer.java
+++ b/lightstep-tracer-android/src/main/java/com/lightstep/tracer/android/Tracer.java
@@ -19,6 +19,8 @@ public class Tracer extends AbstractTracer {
 
   private static final String TAG = "Tracer";
 
+  private static final long DEFAULT_REPORTING_INTERVAL_MILLIS = 30 * 1000;
+
   /**
    * Create a new tracer that will send spans to a LightStep collector.
    *
@@ -30,6 +32,10 @@ public class Tracer extends AbstractTracer {
 
     this.ctx = ctx;
     this.addStandardTracerTags();
+  }
+
+  protected long getDefaultReportingIntervalMillis() {
+      return this.DEFAULT_REPORTING_INTERVAL_MILLIS;
   }
 
   /**

--- a/lightstep-tracer-android/src/main/java/com/lightstep/tracer/android/Tracer.java
+++ b/lightstep-tracer-android/src/main/java/com/lightstep/tracer/android/Tracer.java
@@ -67,8 +67,8 @@ public class Tracer extends AbstractTracer {
 
     @Override
     protected Void doInBackground(Void ...voids) {
-      sendReport(false);
-      this.future.set(false);
+      boolean ok = sendReport(false);
+      this.future.set(ok);
       return null;
     }
   }

--- a/lightstep-tracer-jre/lightstep-tracer-jre.iml
+++ b/lightstep-tracer-jre/lightstep-tracer-jre.iml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.system.id="GRADLE" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="android-gradle" name="Android-Gradle">
+      <configuration>
+        <option name="GRADLE_PROJECT_PATH" value=":" />
+      </configuration>
+    </facet>
+    <facet type="android" name="Android">
+      <configuration>
+        <option name="ALLOW_USER_CONFIGURATION" value="false" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
@@ -8,6 +8,8 @@ import com.lightstep.tracer.thrift.KeyValue;
 
 public class JRETracer extends AbstractTracer {
 
+    private static final long DEFAULT_REPORTING_INTERVAL_MILLIS = 2500;
+
     private static class JavaTracerHolder {
         private static final JRETracer INSTANCE = new JRETracer(null);
     }
@@ -25,8 +27,12 @@ public class JRETracer extends AbstractTracer {
         this.addStandardTracerTags();
     }
 
+    protected long getDefaultReportingIntervalMillis() {
+        return this.DEFAULT_REPORTING_INTERVAL_MILLIS;
+    }
+
     // Flush any data stored in the log and span buffers
-    public SimpleFuture<Boolean> flushInternal() {
+    protected SimpleFuture<Boolean> flushInternal() {
         return new SimpleFuture<Boolean>(sendReport(true));
     }
 

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
@@ -26,8 +26,8 @@ public class JRETracer extends AbstractTracer {
     }
 
     // Flush any data stored in the log and span buffers
-    public void flush() {
-        sendReport(true);
+    public SimpleFuture<Boolean> flushInternal() {
+        return new SimpleFuture<Boolean>(sendReport(true));
     }
 
     protected void printLogToConsole(InternalLogLevel level, String msg, Object payload) {


### PR DESCRIPTION
Improves the Android / JRE reporting loop. Immediate improvements are:

- Reduce the maximum delay before "flush at process exit"
- Add jitter to the reporting interval
- Add back off between reports if there are failures
- Add a timeout to the Thrift report RPCs
- Option to disable automatic reporting interval
- Option to disable report at exit
- Remove the (complicated) need to coordinate daemon and non-daemon threads
- Separate reporting interval defaults for Android & JRE





