### PR TITLE
Add timeout to the reporting thread to not block process exit

### DIFF
--- a/examples/jre-simple/build.gradle
+++ b/examples/jre-simple/build.gradle
@@ -21,12 +21,17 @@ repositories {
 
 dependencies {
     // Toggle the below to alternate between the published and locally built artifacts
-    compile 'com.lightstep.tracer:lightstep-tracer-jre:' + current_version
+    //compile 'com.lightstep.tracer:lightstep-tracer-jre:' + current_version
 
     // The JAR itself does not have the list of the dependencies of the JAR (that's in the
     // pom.xml). Therefore when building locally the transitive dependencies need to be
     // explicitly included here.
-    //compile files("../../lightstep-tracer-jre/build/libs/lightstep-tracer-jre-" + current_version + ".jar")
+    compile files("../../lightstep-tracer-jre/build/libs/lightstep-tracer-jre-" + current_version + ".jar")
+    compile 'io.opentracing:opentracing-api:0.10.0'
+    compile 'org.apache.thrift:libthrift:0.9.2'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
+    compile 'org.json:json:20160212'
+    compile 'javax.annotation:jsr250-api:1.0'
 }
 
 task runSample(type: JavaExec, dependsOn: 'classes') {

--- a/examples/jre-simple/src/main/java/Simple.java
+++ b/examples/jre-simple/src/main/java/Simple.java
@@ -23,6 +23,12 @@ public class Simple {
                 .withVerbosity(4)
         );
 
+        // Create a simple span and delay for a while to ensure the reporting
+        // loop works as expected
+        final Span mySpan = tracer.buildSpan("my_span").start();
+        mySpan.finish();
+        Thread.sleep(4000);
+
         // Create an outer span to capture all activity
         final Span parentSpan = tracer.buildSpan("outer_span").start();
         parentSpan.log("Starting outer span", null);


### PR DESCRIPTION
## Summary

A testing snaffu on the last pull request introduced a regression: the `jre-simple` example runs against the latest *published* version of the Java artifact, which masked a problem in the last PR. 

The "final report on exit" feature regressed in the last PR. The `reportingLoop` thread, a "user" thread rather than "daemon" thread, was preventing the process from exiting as it was always active.

The fix was to add a new variable that tracks when the latest new span was added to the span buffer. If no new data has been seen after a given timeout period, the reporting loop will self-terminate. This allows a process to exit if it is finished. If there's simply a window of inactivity, the thread will be automatically restarted on the next added span.

This PR also updates the `jre-simple` example to build against the current source to prevent such an error in the future.