### PR TITLE
Add support for manual, explicit flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ For reference, the generated LightStep documentation is also available:
 
 To set the name used in the LightStep UI for this instance of the Tracer, call `withComponentName()` on the `Options` object:
 
-```
+```java
 options = new com.lightstep.tracer.shared.Options("{your_access_token}")
     .withComponentName("your_custom_name");
 ```
@@ -151,16 +151,23 @@ options = new com.lightstep.tracer.shared.Options("{your_access_token}")
 
 By default, the Java library does a report of any buffered data on a fairly regular interval. To disable this behavior and rely only on explicit calls to `flush()` to report data, initialize with:
 
-```
+```java
 options = new com.lightstep.tracer.shared.Options("{your_access_token}")
     .withDisableReportingLoop(true);
+```
+
+To then explicitly control reporting, manually flush by using the LightStep tracer object directly:
+
+```java
+// Flush any buffered tracing data
+((com.lightstep.tracer.android.Tracer)tracer).flush();
 ```
 
 ### Disabling the report at exit
 
 By default, the library will send a final report of any remaining buffered data at process exit. To disable this behavior, set the following option:
 
-```
+```java
 options = new com.lightstep.tracer.shared.Options("{your_access_token}")
     .withDisableReportAtExit(true);
 ```

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ options = new com.lightstep.tracer.shared.Options("{your_access_token}")
     .withDisableReportingLoop(true);
 ```
 
-To then explicitly control reporting, manually flush by using the LightStep tracer object directly:
+To then manually flush by using the LightStep tracer object directly:
 
 ```java
 // Flush any buffered tracing data

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -235,7 +235,7 @@ public abstract class AbstractTracer implements Tracer {
           // not have a wireless connection.
           long nowMillis = System.currentTimeMillis();
           if (nowMillis >= nextReportMillis) {
-            SimpleFuture<Boolean> result = AbstractTracer.this.flushInternal();
+            SimpleFuture<Boolean> result = AbstractTracer.this.flushInternal(false);
             boolean reportSucceeded = false;
             try {
               reportSucceeded = result.get();
@@ -383,15 +383,12 @@ public abstract class AbstractTracer implements Tracer {
   }
 
   public void flush() {
-    // TODO: does OpenTracing specify if this is a synchronous or asynchronous method?
-    // It seems like it would have to be synchronous (i.e. this method should wait for
-    // the promise retunred by flushInternal() to complete), but the current LightStep
-    // implementation code calls this in several places and *may* be relying on the
-    // current async behavior.
-    this.flushInternal();
+    // TODO: flush() likely needs some form of synchronization mechanism to notify the caller
+    // when the flush is complete. For example, a promise, a callback, etc.
+    this.flushInternal(true);
   }
 
-  protected abstract SimpleFuture<Boolean> flushInternal();
+  protected abstract SimpleFuture<Boolean> flushInternal(boolean explicitRequest);
 
   /**
    * Does the work of a flush by sending spans to the collector.

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
@@ -32,8 +32,8 @@ public class JRETracer extends AbstractTracer {
     }
 
     // Flush any data stored in the log and span buffers
-    protected SimpleFuture<Boolean> flushInternal() {
-        return new SimpleFuture<Boolean>(sendReport(true));
+    protected SimpleFuture<Boolean> flushInternal(boolean explicitRequest) {
+        return new SimpleFuture<Boolean>(sendReport(explicitRequest));
     }
 
     protected void printLogToConsole(InternalLogLevel level, String msg, Object payload) {


### PR DESCRIPTION
## Summary

Adds support for manual, explicit calls to flush the tracer's buffered tracing data. Support for this functionality was mostly already present and only a small change related to the clock state synchronization was needed.

The updated README describes how the manual flush call can be used:

------

By default, the Java library does a report of any buffered data on a fairly regular interval. To disable this behavior and rely only on explicit calls to `flush()` to report data, initialize with:

```java
options = new com.lightstep.tracer.shared.Options("{your_access_token}")
    .withDisableReportingLoop(true);
```

Then manually flush by using the LightStep tracer object directly:

```java
// Flush any buffered tracing data
((com.lightstep.tracer.android.Tracer)tracer).flush();
```