### PR TITLE
Remove Jackson dep

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/NoopSpan.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/NoopSpan.java
@@ -58,6 +58,11 @@ class NoopSpan implements Span {
     return this;
   }
 
+  @Override
+  public Span setOperationName(String operationName) {
+    return this;
+  }
+
   private static class NoopSpanContext implements SpanContext {
     @Override
     public Iterable<Map.Entry<String, String>> baggageItems() {

--- a/common/src/main/java/com/lightstep/tracer/shared/Span.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Span.java
@@ -128,7 +128,11 @@ public class Span implements io.opentracing.Span {
     log.setMessage(message);
 
     if (payload != null) {
-      log.setPayload_json(JSONObject.wrap(payload).toString());
+      if (payload instanceof String) {
+        log.setPayload_json(JSONObject.quote((String)payload));
+      } else {
+        log.setPayload_json(JSONObject.wrap(payload).toString());
+      }
     }
 
     synchronized (this.mutex) {

--- a/lightstep-tracer-android/build.gradle
+++ b/lightstep-tracer-android/build.gradle
@@ -143,12 +143,11 @@ repositories {
 }
 
 dependencies {
-    compile 'io.opentracing:opentracing-api:0.14.0'
+    compile 'io.opentracing:opentracing-api:0.15.0'
     compile('org.apache.thrift:libthrift:0.9.2') {
         // Not needed on Android
         exclude module: 'httpclient'
     }
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
     compile 'javax.annotation:jsr250-api:1.0'
 }
 

--- a/lightstep-tracer-jre/build.gradle
+++ b/lightstep-tracer-jre/build.gradle
@@ -62,9 +62,8 @@ repositories {
 
 // Dependencies to build this JAR archive
 dependencies {
-    compile 'io.opentracing:opentracing-api:0.14.0'
+    compile 'io.opentracing:opentracing-api:0.15.0'
     compile 'org.apache.thrift:libthrift:0.9.2'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.4'
     compile 'org.json:json:20160212'
     compile 'javax.annotation:jsr250-api:1.0'
     testCompile 'junit:junit:4.11'


### PR DESCRIPTION
In the process, make Object->JSON work less-well... but not a big deal in light of https://github.com/lightstep/lightstep-tracer-java/issues/39

Also, add support for `Span.setOperationName` which was recently incorporated into the OT Span API.