### PR TITLE
Set compileSdkVersion to 18 (and make corresponding fixes)

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -595,6 +595,7 @@ public abstract class AbstractTracer implements Tracer {
         // cross-platform, Java 6-compatible way to determine that
         return new Random(
           System.currentTimeMillis() *
+          (long)(System.nanoTime() % 1000000) * 
           Thread.currentThread().getId() *
           (long)(1024 * Math.random()));
       }

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -13,7 +13,7 @@ import java.util.Random;
 import java.util.StringTokenizer;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -127,7 +127,7 @@ public abstract class AbstractTracer implements Tracer {
 
     this.clockState = new ClockState();
     this.clientMetrics = new ClientMetrics();
-    this.visibleErrorCount = 0; 
+    this.visibleErrorCount = 0;
 
     this.auth = new Auth();
     auth.setAccess_token(options.accessToken);
@@ -203,8 +203,8 @@ public abstract class AbstractTracer implements Tracer {
     }
   }
 
-  /** 
-   * This call is NOT synchronized 
+  /**
+   * This call is NOT synchronized
    */
   void doStopReporting() {
     synchronized (this) {
@@ -222,7 +222,7 @@ public abstract class AbstractTracer implements Tracer {
 
   /**
    * This call is synchronized
-   */ 
+   */
   void maybeStartReporting() {
     if (this.reportingThread != null) {
       return;
@@ -237,9 +237,9 @@ public abstract class AbstractTracer implements Tracer {
     }
   }
 
-  /** 
+  /**
    * setDefaultReportingIntervalMillis modifies the Options' maximum
-   * reporting interval if the user has not specified a value. 
+   * reporting interval if the user has not specified a value.
    */
   protected static Options setDefaultReportingIntervalMillis(Options input, int value) {
     if (input.maxReportingIntervalMillis != 0) {
@@ -582,9 +582,27 @@ public abstract class AbstractTracer implements Tracer {
     }
   }
 
+  /**
+   * Thread-specific random number generators. Each is seeded with the thread
+   * ID, so the sequence of pseudo-random numbers are unique between threads.
+   *
+   * See http://stackoverflow.com/questions/2546078/java-random-long-number-in-0-x-n-range
+   */
+  private static ThreadLocal<Random> random = new ThreadLocal<Random>() {
+      @Override
+      protected Random initialValue() {
+        // It'd be nice to get the process ID into the mix, but there's no clear
+        // cross-platform, Java 6-compatible way to determine that
+        return new Random(
+          System.currentTimeMillis() *
+          Thread.currentThread().getId() *
+          (long)(1024 * Math.random()));
+      }
+  };
+
   static final String generateGUID() {
     // Note that ThreadLocalRandom is a singleton, thread safe Random Generator
-    long guid = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE);
+    long guid = AbstractTracer.random.get().nextLong();
     return Long.toHexString(guid);
   }
 

--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -595,7 +595,7 @@ public abstract class AbstractTracer implements Tracer {
         // cross-platform, Java 6-compatible way to determine that
         return new Random(
           System.currentTimeMillis() *
-          (long)(System.nanoTime() % 1000000) * 
+          (System.nanoTime() % 1000000) * 
           Thread.currentThread().getId() *
           (long)(1024 * Math.random()));
       }

--- a/common/src/main/java/com/lightstep/tracer/shared/Propagator.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Propagator.java
@@ -12,7 +12,7 @@ public interface Propagator<C> {
   void inject(SpanContext spanContext, C carrier);
   SpanContext extract(C carrier);
 
-  
+
 
   // The three supported Propagators.
   static final Propagator<TextMap> TEXT_MAP = new Propagator<TextMap>() {
@@ -37,25 +37,20 @@ public interface Propagator<C> {
       int requiredFieldCount = 0;
       String traceId = null, spanId = null;
       Map<String,String> decodedBaggage = null;
+      
       for (Map.Entry<String,String> entry : carrier) {
-        switch (entry.getKey()) {
-          case FIELD_NAME_TRACE_ID: {
-            requiredFieldCount++;
-            traceId = entry.getValue();
-            break;
-          }
-          case FIELD_NAME_SPAN_ID: {
-            requiredFieldCount++;
-            spanId = entry.getValue();
-            break;
-          }
-          default: {
-            String key = entry.getKey();
-            if (key.startsWith(PREFIX_BAGGAGE)) {
-              if (decodedBaggage == null) {
-                decodedBaggage = new HashMap<String,String>();
-                decodedBaggage.put(key.substring(PREFIX_BAGGAGE.length()), entry.getValue());
-              }
+        final String key = entry.getKey();
+        if (key == FIELD_NAME_TRACE_ID) {
+          requiredFieldCount++;
+          traceId = entry.getValue();
+        } else if (key == FIELD_NAME_SPAN_ID) {
+          requiredFieldCount++;
+          spanId = entry.getValue();
+        } else {
+          if (key.startsWith(PREFIX_BAGGAGE)) {
+            if (decodedBaggage == null) {
+               decodedBaggage = new HashMap<String,String>();
+              decodedBaggage.put(key.substring(PREFIX_BAGGAGE.length()), entry.getValue());
             }
           }
         }

--- a/common/src/main/java/com/lightstep/tracer/shared/Propagator.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Propagator.java
@@ -37,7 +37,7 @@ public interface Propagator<C> {
       int requiredFieldCount = 0;
       String traceId = null, spanId = null;
       Map<String,String> decodedBaggage = null;
-      
+
       for (Map.Entry<String,String> entry : carrier) {
         final String key = entry.getKey();
         if (key == FIELD_NAME_TRACE_ID) {
@@ -49,7 +49,7 @@ public interface Propagator<C> {
         } else {
           if (key.startsWith(PREFIX_BAGGAGE)) {
             if (decodedBaggage == null) {
-               decodedBaggage = new HashMap<String,String>();
+              decodedBaggage = new HashMap<String,String>();
               decodedBaggage.put(key.substring(PREFIX_BAGGAGE.length()), entry.getValue());
             }
           }

--- a/common/src/main/java/com/lightstep/tracer/shared/SpanContext.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SpanContext.java
@@ -35,9 +35,9 @@ public class SpanContext implements io.opentracing.SpanContext {
   public SpanContext withBaggageItem(String key, String value) {
     Map<String, String> baggageCopy;
     if (baggage == null) {
-      baggageCopy = new HashMap<>();
+      baggageCopy = new HashMap<String, String>();
     } else {
-      baggageCopy = new HashMap<>(baggage);
+      baggageCopy = new HashMap<String, String>(baggage);
     }
     baggageCopy.put(key, value);
     return new SpanContext(traceId, spanId, baggageCopy);

--- a/examples/android-demo/.idea/gradle.xml
+++ b/examples/android-demo/.idea/gradle.xml
@@ -12,12 +12,7 @@
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
-        <option name="myModules">
-          <set>
-            <option value="$PROJECT_DIR$" />
-            <option value="$PROJECT_DIR$/app" />
-          </set>
-        </option>
+        <option name="resolveModulePerSourceSet" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/lightstep-tracer-android/build.gradle
+++ b/lightstep-tracer-android/build.gradle
@@ -33,7 +33,7 @@ def siteUrl = 'https://github.com/lightstep/lightstep-tracer-java'
 def gitUrl = 'https://github.com/lightstep/lightstep-tracer-java.git'
 
 android {
-    compileSdkVersion 21
+    compileSdkVersion 18
     buildToolsVersion "22.0.1"
     resourcePrefix "lightstep__"
 
@@ -55,13 +55,6 @@ android {
                 srcDirs = [ "src/main", "../common/src"]
             }
         }
-    }
-
-    // lint throws an InvalidPackage error for java.nio.file, javax.security.sasl, javax.servlet.http, and javax.servlet.
-    // For now, I'm just going to ignore them.
-    lintOptions {
-        disable 'InvalidPackage'
-        abortOnError false
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #42 but removing usage of APIs not available in Android SDK 18. The library was causing crashes on JellyBean due to such calls.

* Replaces `ThreadLocalRandom` with an equivalent directly using `ThreadLocal` and `Random`
* Adds a unit test to make sure the equivalent class behaves reasonably :)
* Changes the build settings so `compileSdkVersion` is now 18
* A couple other minor language-level changes to handle the lower `compileSdkVersion`
* Removes the disabled `lintOptions` that were added in very early development (and should have been removed some time ago)

