### PR TITLE
Restrict access-level of variables and methods

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -47,11 +47,15 @@ public abstract class AbstractTracer implements Tracer {
     private static final int DEFAULT_PLAINTEXT_PORT = 80;
     private static final String COLLECTOR_PATH = "/_rpc/v1/reports/binary";
 
-    public static final String LIGHTSTEP_TRACER_PLATFORM_KEY = "lightstep.tracer_platform";
-    public static final String LIGHTSTEP_TRACER_PLATFORM_VERSION_KEY = "lightstep.tracer_platform_version";
-    public static final String LIGHTSTEP_TRACER_VERSION_KEY = "lightstep.tracer_version";
-    public static final String LEGACY_COMPONENT_NAME_KEY = "component_name";
+    protected static final String LIGHTSTEP_TRACER_PLATFORM_KEY = "lightstep.tracer_platform";
+    protected static final String LIGHTSTEP_TRACER_PLATFORM_VERSION_KEY = "lightstep.tracer_platform_version";
+    protected static final String LIGHTSTEP_TRACER_VERSION_KEY = "lightstep.tracer_version";
+    private static final String LEGACY_COMPONENT_NAME_KEY = "component_name";
+
+    @SuppressWarnings("WeakerAccess")
     public static final String COMPONENT_NAME_KEY = "lightstep.component_name";
+
+    @SuppressWarnings("WeakerAccess")
     public static final String GUID_KEY = "lightstep.guid";
 
     protected static final int VERBOSITY_DEBUG = 4;
@@ -75,7 +79,7 @@ public abstract class AbstractTracer implements Tracer {
      * The tag key used to record the relationship between child and parent
      * spans.
      */
-    public static final String PARENT_SPAN_GUID_KEY = "parent_span_guid";
+    private static final String PARENT_SPAN_GUID_KEY = "parent_span_guid";
 
     // copied from options
     private final int maxBufferedSpans;
@@ -200,7 +204,7 @@ public abstract class AbstractTracer implements Tracer {
     /**
      * This call is NOT synchronized
      */
-    void doStopReporting() {
+    private void doStopReporting() {
         synchronized (this) {
             // Note: There is no synchronization to prevent multiple
             // reporting loops from running simultaneously.  It's possible
@@ -217,7 +221,7 @@ public abstract class AbstractTracer implements Tracer {
     /**
      * This call is synchronized
      */
-    void maybeStartReporting() {
+    private void maybeStartReporting() {
         if (this.reportingThread != null) {
             return;
         }
@@ -250,7 +254,7 @@ public abstract class AbstractTracer implements Tracer {
      * case of Android, this thread will block and wait until the Android
      * AsyncTask finishes.
      */
-    class ReportingLoop implements Runnable {
+    private class ReportingLoop implements Runnable {
         // Controls how often the reporting loop itself checks if the status.
         private static final int POLL_INTERVAL_MILLIS = 40;
 
@@ -317,7 +321,7 @@ public abstract class AbstractTracer implements Tracer {
          * a report should be attempted.  Accounts for clock state, error back off,
          * and random jitter.
          */
-        protected long computeNextReportMillis() {
+        long computeNextReportMillis() {
             double base;
             if (!AbstractTracer.this.clockState.isReady()) {
                 base = (double) DEFAULT_CLOCK_STATE_INTERVAL_MILLIS;
@@ -345,7 +349,7 @@ public abstract class AbstractTracer implements Tracer {
      * if the consumer has not alreayd called it, *must* be called internally by
      * the library to cancel the timer.
      */
-    public void shutdown() {
+    private void shutdown() {
         if (isDisabled) {
             return;
         }
@@ -463,7 +467,7 @@ public abstract class AbstractTracer implements Tracer {
      * Note: this method acquires the mutex. In Java synchronized locks are reentrant, but if the
      * lock is already acquired, calling spans.size() directly should suffice.
      */
-    protected int unreportedSpanCount() {
+    private int unreportedSpanCount() {
         synchronized (this.mutex) {
             return this.spans.size();
         }
@@ -623,7 +627,7 @@ public abstract class AbstractTracer implements Tracer {
         this.runtime.addToAttrs(new KeyValue(key, value));
     }
 
-    class SpanBuilder implements Tracer.SpanBuilder {
+    private class SpanBuilder implements Tracer.SpanBuilder {
         private String operationName;
         private SpanContext parent;
         private Map<String, String> tags;
@@ -755,14 +759,14 @@ public abstract class AbstractTracer implements Tracer {
     /**
      * Internal logging.
      */
-    protected void warn(String s) {
+    private void warn(String s) {
         this.warn(s, null);
     }
 
     /**
      * Internal warning.
      */
-    protected void warn(String msg, Object payload) {
+    private void warn(String msg, Object payload) {
         if (this.verbosity < VERBOSITY_INFO) {
             return;
         }
@@ -798,7 +802,7 @@ public abstract class AbstractTracer implements Tracer {
      */
     public class Status {
         public Map<String, String> tags;
-        public ClientMetrics clientMetrics;
+        ClientMetrics clientMetrics;
 
         public Status() {
             this.tags = new HashMap<>();
@@ -837,7 +841,7 @@ public abstract class AbstractTracer implements Tracer {
                 new KeyValue(COMPONENT_NAME_KEY, componentName));
     }
 
-    protected long nowMicrosApproximate() {
+    private long nowMicrosApproximate() {
         return System.currentTimeMillis() * 1000;
     }
 }

--- a/common/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/ClientMetrics.java
@@ -5,30 +5,35 @@ import java.util.ArrayList;
 import com.lightstep.tracer.thrift.Metrics;
 import com.lightstep.tracer.thrift.MetricsSample;
 
-public class ClientMetrics {
+/**
+ * Tracks the number of spans dropped due to buffering limits.
+ */
+class ClientMetrics {
 
-    // For capacity allocation purposes, keep this in sync with the number of
-    // counts actually being tracked.
+    /**
+     * For capacity allocation purposes, keep this in sync with the number of counts actually being
+     * tracked.
+     */
     private static final int NUMBER_OF_COUNTS = 1;
 
-    public long spansDropped;
+    long spansDropped;
 
-    public ClientMetrics() {
+    ClientMetrics() {
         this.spansDropped = 0;
     }
 
-    public ClientMetrics(ClientMetrics that) {
+    ClientMetrics(ClientMetrics that) {
         this.spansDropped = that.spansDropped;
     }
 
-    public void merge(ClientMetrics that) {
+    void merge(ClientMetrics that) {
         if (that == null) {
             return;
         }
         this.spansDropped += that.spansDropped;
     }
 
-    public Metrics toThrift() {
+    Metrics toThrift() {
         ArrayList<MetricsSample> counts = new ArrayList<>(NUMBER_OF_COUNTS);
         counts.add(new MetricsSample("spans.dropped").setInt64_value(spansDropped));
         return new Metrics().setCounts(counts);

--- a/common/src/main/java/com/lightstep/tracer/shared/ClockState.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/ClockState.java
@@ -4,7 +4,7 @@ import java.util.LinkedList;
 
 import static java.lang.Long.MAX_VALUE;
 
-public class ClockState {
+class ClockState {
     /**
      * How many updates before a sample is considered old. This happens to
      * be one less than the number of samples in our buffer but that's

--- a/common/src/main/java/com/lightstep/tracer/shared/NoopSpan.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/NoopSpan.java
@@ -10,7 +10,7 @@ import io.opentracing.SpanContext;
 class NoopSpan implements Span {
 
     static final Span INSTANCE = new NoopSpan();
-    static final SpanContext CONTEXT = new NoopSpanContext();
+    private static final SpanContext CONTEXT = new NoopSpanContext();
 
     private NoopSpan() {
     }

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -13,18 +13,18 @@ public final class Options implements Cloneable {
     /**
      * The unique identifier for this application.
      */
-    public String accessToken;
+    String accessToken;
 
     /**
      * The host to which the tracer will send data.  If null, the default will be used.
      */
-    public String collectorHost;
+    String collectorHost;
 
     /**
      * The port to which the tracer will send data.  If 0, the default will be
      * used.
      */
-    public int collectorPort;
+    int collectorPort;
 
     /**
      * Encryption describes methods of protecting data sent from the tracer to
@@ -46,13 +46,13 @@ public final class Options implements Cloneable {
     /**
      * Determines how the tracer communicates with the collector.
      */
-    public Encryption collectorEncryption = Encryption.TLS;
+    Encryption collectorEncryption = Encryption.TLS;
 
     /**
      * User-defined key-value pairs that should be associated with all of the
      * data produced by this tracer.
      */
-    public Map<String, Object> tags = new HashMap<>();
+    Map<String, Object> tags = new HashMap<>();
 
     /**
      * UNSUPPORTED API: intended for unit testing purposes only and should
@@ -61,12 +61,12 @@ public final class Options implements Cloneable {
      * Production control of limits will be via a throughput-based limit on
      * resource use.
      */
-    public int maxBufferedSpans;
+    int maxBufferedSpans;
 
     /**
      * Maximum interval between reports. If zero, the default will be used.
      */
-    public int maxReportingIntervalMillis;
+    int maxReportingIntervalMillis;
 
     /**
      * Controls the amount of local output produced by the tracer.  It does not
@@ -79,18 +79,18 @@ public final class Options implements Cloneable {
      * 3 - all errors, warnings, and info statements are echoed locally
      * 4 - all internal log statements, including debugging details
      */
-    public int verbosity;
+    int verbosity;
 
     /**
      * If true, the background reporting loop will be disabled. Reports will
      * only occur on explicit calls to Flush();
      */
-    public boolean disableReportingLoop;
+    boolean disableReportingLoop;
 
     /**
      * If true, the library will *not* attempt an automatic report at process exit.
      */
-    public boolean disableReportOnExit;
+    boolean disableReportOnExit;
 
     public Options(String accessToken) {
         this.accessToken = accessToken;
@@ -99,21 +99,25 @@ public final class Options implements Cloneable {
         this.disableReportOnExit = false;
     }
 
+    @SuppressWarnings("unused")
     public Options withAccessToken(String accessToken) {
         this.accessToken = accessToken;
         return this;
     }
 
+    @SuppressWarnings("unused")
     public Options withCollectorHost(String collectorHost) {
         this.collectorHost = collectorHost;
         return this;
     }
 
+    @SuppressWarnings("unused")
     public Options withCollectorPort(int collectorPort) {
         this.collectorPort = collectorPort;
         return this;
     }
 
+    @SuppressWarnings("unused")
     public Options withCollectorEncryption(Encryption collectorEncryption) {
         this.collectorEncryption = collectorEncryption;
         return this;
@@ -123,11 +127,13 @@ public final class Options implements Cloneable {
         return this.withTag(COMPONENT_NAME_KEY, name);
     }
 
+    @SuppressWarnings("WeakerAccess")
     public Options withTag(String key, Object value) {
         this.tags.put(key, value);
         return this;
     }
 
+    @SuppressWarnings("WeakerAccess")
     public Options withMaxReportingIntervalMillis(int maxReportingIntervalMillis) {
         this.maxReportingIntervalMillis = maxReportingIntervalMillis;
         return this;
@@ -138,11 +144,13 @@ public final class Options implements Cloneable {
         return this;
     }
 
+    @SuppressWarnings("unused")
     public Options withDisableReportingLoop(boolean disable) {
         this.disableReportingLoop = true;
         return this;
     }
 
+    @SuppressWarnings("unused")
     public Options withDisableReportOnExit(boolean disable) {
         this.disableReportOnExit = true;
         return this;
@@ -159,6 +167,7 @@ public final class Options implements Cloneable {
     /**
      * UNSUPPORTED API: intended for unit testing purposes only.
      */
+    @SuppressWarnings("unused")
     public Options withMaxBufferedSpans(int max) {
         this.maxBufferedSpans = max;
         return this;

--- a/common/src/main/java/com/lightstep/tracer/shared/Propagator.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Propagator.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import io.opentracing.propagation.TextMap;
 
-public interface Propagator<C> {
+interface Propagator<C> {
     void inject(SpanContext spanContext, C carrier);
 
     SpanContext extract(C carrier);
@@ -17,7 +17,6 @@ public interface Propagator<C> {
         private static final String PREFIX_TRACER_STATE = "ot-tracer-";
         private static final String PREFIX_BAGGAGE = "ot-baggage-";
 
-        private static final int TRACER_STATE_FIELD_COUNT = 3;
         private static final String FIELD_NAME_TRACE_ID = PREFIX_TRACER_STATE + "traceid";
         private static final String FIELD_NAME_SPAN_ID = PREFIX_TRACER_STATE + "spanid";
         private static final String FIELD_NAME_SAMPLED = PREFIX_TRACER_STATE + "sampled";

--- a/common/src/main/java/com/lightstep/tracer/shared/SimpleFuture.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SimpleFuture.java
@@ -36,6 +36,7 @@ public class SimpleFuture<T> {
         return this.value;
     }
 
+    @SuppressWarnings("unused")
     public T getWithTimeout(long millis) throws InterruptedException {
         if (!resolved) {
             synchronized (this) {

--- a/common/src/main/java/com/lightstep/tracer/shared/Span.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Span.java
@@ -183,10 +183,6 @@ public class Span implements io.opentracing.Span {
         }
     }
 
-    public SpanRecord thriftRecord() {
-        return this.record;
-    }
-
     private long nowMicros() {
         // Note that this.startTimestampRelativeNanos will be -1 if the user
         // provided an explicit start timestamp in the SpanBuilder.

--- a/common/src/main/java/com/lightstep/tracer/shared/SpanContext.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/SpanContext.java
@@ -27,14 +27,14 @@ public class SpanContext implements io.opentracing.SpanContext {
         return this.traceId;
     }
 
-    public String getBaggageItem(String key) {
+    String getBaggageItem(String key) {
         if (this.baggage == null) {
             return null;
         }
         return this.baggage.get(key);
     }
 
-    public SpanContext withBaggageItem(String key, String value) {
+    SpanContext withBaggageItem(String key, String value) {
         Map<String, String> baggageCopy;
         if (baggage == null) {
             baggageCopy = new HashMap<>();

--- a/examples/android-demo/src/main/java/com/lightstep/samples/sampleapp/MainActivityFragment.java
+++ b/examples/android-demo/src/main/java/com/lightstep/samples/sampleapp/MainActivityFragment.java
@@ -227,7 +227,7 @@ public class MainActivityFragment extends Fragment {
         }
     }
 
-    class WrappedRequest extends StringRequest {
+    private class WrappedRequest extends StringRequest {
         private final com.lightstep.tracer.shared.Span span;
 
         WrappedRequest(final Span span, String url,

--- a/examples/jre-simple/src/main/java/Simple.java
+++ b/examples/jre-simple/src/main/java/Simple.java
@@ -93,7 +93,7 @@ public class Simple {
     }
 
     // An ultra-hacky demonstration of inject() and extract() in-process.
-    public static Span createChildViaInjectExtract(Tracer tracer, String opName, SpanContext parentCtx) {
+    private static Span createChildViaInjectExtract(Tracer tracer, String opName, SpanContext parentCtx) {
         final Map<String, String> textMap = new HashMap<>();
         final TextMap demoCarrier = new TextMap() {
             public void put(String key, String value) {
@@ -116,7 +116,7 @@ public class Simple {
         return tracer.buildSpan(opName).asChildOf(extracted).start();
     }
 
-    public static void spawnWorkers(final Tracer tracer, Span outerSpan) throws InterruptedException {
+    private static void spawnWorkers(final Tracer tracer, Span outerSpan) throws InterruptedException {
         final Span parentSpan = tracer.buildSpan("spawn_workers")
                 .asChildOf(outerSpan.context())
                 .start();

--- a/lightstep-tracer-android/src/main/java/com/lightstep/tracer/android/Tracer.java
+++ b/lightstep-tracer-android/src/main/java/com/lightstep/tracer/android/Tracer.java
@@ -9,7 +9,8 @@ import android.util.Log;
 import com.lightstep.tracer.shared.AbstractTracer;
 import com.lightstep.tracer.shared.Options;
 import com.lightstep.tracer.shared.SimpleFuture;
-import com.lightstep.tracer.shared.Version;
+
+import static com.lightstep.tracer.shared.Version.LIGHTSTEP_TRACER_VERSION;
 
 public class Tracer extends AbstractTracer {
     private final Context ctx;
@@ -77,12 +78,12 @@ public class Tracer extends AbstractTracer {
     /**
      * Adds standard tags set by all LightStep client libraries.
      */
-    protected void addStandardTracerTags() {
+    private void addStandardTracerTags() {
         // The platform is called "jre" rather than "Java" to clearly
         // differentiate this library from the Android version
         this.addTracerTag(LIGHTSTEP_TRACER_PLATFORM_KEY, "android");
         this.addTracerTag(LIGHTSTEP_TRACER_PLATFORM_VERSION_KEY, String.valueOf(android.os.Build.VERSION.SDK_INT));
-        this.addTracerTag(LIGHTSTEP_TRACER_VERSION_KEY, Version.LIGHTSTEP_TRACER_VERSION);
+        this.addTracerTag(LIGHTSTEP_TRACER_VERSION_KEY, LIGHTSTEP_TRACER_VERSION);
 
         // Check to see if component name is set and, if not, use the app process
         // or package name.

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/JRETracer.java
@@ -3,7 +3,6 @@ package com.lightstep.tracer.jre;
 import com.lightstep.tracer.shared.AbstractTracer;
 import com.lightstep.tracer.shared.Options;
 import com.lightstep.tracer.shared.SimpleFuture;
-import com.lightstep.tracer.shared.Version;
 
 import java.util.HashMap;
 
@@ -22,6 +21,7 @@ public class JRETracer extends AbstractTracer {
      *
      * @return tracer instance
      */
+    @SuppressWarnings("unused")
     public static JRETracer getInstance() {
         return JavaTracerHolder.INSTANCE;
     }
@@ -62,15 +62,10 @@ public class JRETracer extends AbstractTracer {
         System.err.println(s);
     }
 
-    protected HashMap<String, String> retrieveDeviceInfo() {
-        // TODO: Implement for Java Desktop Applications
-        return null;
-    }
-
     /**
      * Adds standard tags set by all LightStep client libraries.
      */
-    protected void addStandardTracerTags() {
+    private void addStandardTracerTags() {
         // The platform is called "jre" rather than "Java" to clearly
         // differentiate this library from the Android version
         this.addTracerTag(LIGHTSTEP_TRACER_PLATFORM_KEY, "jre");


### PR DESCRIPTION
"lightstep.*" keys should for the most part be handled internally
by lightstep and not set by clients. Thus these variables are now
made private or protected. The exceptions being compoent_name
and guid, which can be set by clients via Options.

In some cases methods appeared not to be in use, but are part of
the API, these have been marked with @SuppressWarnings("unused")
to make it clear they are part of the API.