### PR TITLE
Unit tests of AbstractTracer log methods

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -32,6 +32,9 @@ import io.opentracing.propagation.TextMap;
 
 import static com.lightstep.tracer.shared.AbstractTracer.InternalLogLevel.DEBUG;
 import static com.lightstep.tracer.shared.AbstractTracer.InternalLogLevel.ERROR;
+import static com.lightstep.tracer.shared.Options.VERBOSITY_DEBUG;
+import static com.lightstep.tracer.shared.Options.VERBOSITY_FIRST_ERROR_ONLY;
+import static com.lightstep.tracer.shared.Options.VERBOSITY_INFO;
 import static io.opentracing.References.CHILD_OF;
 import static io.opentracing.References.FOLLOWS_FROM;
 
@@ -57,12 +60,6 @@ public abstract class AbstractTracer implements Tracer {
 
     @SuppressWarnings("WeakerAccess")
     public static final String GUID_KEY = "lightstep.guid";
-
-    protected static final int VERBOSITY_DEBUG = 4;
-    protected static final int VERBOSITY_INFO = 3;
-    protected static final int VERBOSITY_ERRORS_ONLY = 2;
-    protected static final int VERBOSITY_FIRST_ERROR_ONLY = 1;
-    protected static final int VERBOSITY_NONE = 0;
 
     /**
      * For mapping internal logs to Android log levels without importing Android
@@ -759,14 +756,14 @@ public abstract class AbstractTracer implements Tracer {
     /**
      * Internal logging.
      */
-    private void warn(String s) {
+    protected void warn(String s) {
         this.warn(s, null);
     }
 
     /**
      * Internal warning.
      */
-    private void warn(String msg, Object payload) {
+    protected void warn(String msg, Object payload) {
         if (this.verbosity < VERBOSITY_INFO) {
             return;
         }

--- a/common/src/main/java/com/lightstep/tracer/shared/Options.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/Options.java
@@ -11,6 +11,31 @@ import static com.lightstep.tracer.shared.AbstractTracer.COMPONENT_NAME_KEY;
 public final class Options implements Cloneable {
 
     /**
+     * all internal log statements, including debugging details
+     */
+    public static final int VERBOSITY_DEBUG = 4;
+
+    /**
+     * all errors, warnings, and info statements are echoed locally
+     */
+    public static final int VERBOSITY_INFO = 3;
+
+    /**
+     * all errors are echoed locally
+     */
+    public static final int VERBOSITY_ERRORS_ONLY = 2;
+
+    /**
+     * only the first error encountered will be echoed locally
+     */
+    public static final int VERBOSITY_FIRST_ERROR_ONLY = 1;
+
+    /**
+     * never produce local output
+     */
+    public static final int VERBOSITY_NONE = 0;
+
+    /**
      * The unique identifier for this application.
      */
     String accessToken;

--- a/common/src/test/java/com/lightstep/tracer/shared/AbstractTracerTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/AbstractTracerTest.java
@@ -1,0 +1,92 @@
+package com.lightstep.tracer.shared;
+
+import org.junit.Test;
+
+import static com.lightstep.tracer.shared.Options.VERBOSITY_DEBUG;
+import static com.lightstep.tracer.shared.Options.VERBOSITY_ERRORS_ONLY;
+import static com.lightstep.tracer.shared.Options.VERBOSITY_FIRST_ERROR_ONLY;
+import static com.lightstep.tracer.shared.Options.VERBOSITY_INFO;
+import static com.lightstep.tracer.shared.Options.VERBOSITY_NONE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AbstractTracerTest {
+
+    private static final String ACCESS_TOKEN = "abc123";
+    private static final String TEST_MSG = "hello tracer";
+
+    /**
+     * Provides an implementation of AbstractTracer (for use in testing) that is configured to
+     * the provided verbosity level.
+     */
+    private StubTracer createTracer(int verbosity) {
+        Options options = new Options(ACCESS_TOKEN);
+        options.withVerbosity(verbosity);
+        return createTracer(options);
+    }
+
+    /**
+     * Provides an implementation of AbstractTracer (for use in testing) that is configured with
+     * the provided Options.
+     */
+    private StubTracer createTracer(Options options) {
+        return new StubTracer(options);
+    }
+
+    @Test
+    public void testVerbosityDebug() {
+        StubTracer undertest = createTracer(VERBOSITY_DEBUG);
+        callAllLogMethods(undertest);
+
+        // At debug level, all of the calls should be logged
+        assertEquals(4, undertest.getNumberOfConsoleLogCalls());
+    }
+
+    @Test
+    public void testVerbosityInfo() {
+        StubTracer undertest = createTracer(VERBOSITY_INFO);
+        callAllLogMethods(undertest);
+
+        // At info level, all of the calls should be logged, except the debug log
+        assertEquals(3, undertest.getNumberOfConsoleLogCalls());
+    }
+
+    @Test
+    public void testVerbosityErrorsOnly() {
+        StubTracer undertest = createTracer(VERBOSITY_ERRORS_ONLY);
+        callAllLogMethods(undertest);
+        undertest.error(TEST_MSG); // make an extra call to error, all error calls should be logged
+
+        // At error level, all of the error calls should be logged
+        assertEquals(2, undertest.getNumberOfConsoleLogCalls());
+    }
+
+    @Test
+    public void testVerbosityNone() {
+        StubTracer undertest = createTracer(VERBOSITY_NONE);
+        callAllLogMethods(undertest);
+
+        // At none, nothing should be logged
+        assertTrue(undertest.consoleLogCallsIsEmpty());
+    }
+
+    @Test
+    public void testVerbosityFirstErrorOnly() {
+        StubTracer undertest = createTracer(VERBOSITY_FIRST_ERROR_ONLY);
+        callAllLogMethods(undertest);
+        undertest.error(TEST_MSG); // make a second call to error
+
+        // At error level, only the first error call should be logged
+        assertEquals(1, undertest.getNumberOfConsoleLogCalls());
+    }
+
+    /**
+     * Calls each of the available logging methods on the tracer with a dummy message.
+     */
+    private void callAllLogMethods(StubTracer undertest) {
+        undertest.debug(TEST_MSG);
+        undertest.info(TEST_MSG);
+        undertest.warn(TEST_MSG);
+        undertest.error(TEST_MSG);
+    }
+}

--- a/common/src/test/java/com/lightstep/tracer/shared/StubTracer.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/StubTracer.java
@@ -1,0 +1,56 @@
+package com.lightstep.tracer.shared;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Basic implementation of AbstractTracer for use in unit testing.
+ */
+class StubTracer extends AbstractTracer {
+    private final List<LogCall> consoleLogCalls;
+
+    StubTracer(Options options) {
+        super(options);
+        consoleLogCalls = new ArrayList<>();
+    }
+
+    @Override
+    protected SimpleFuture<Boolean> flushInternal(boolean explicitRequest) {
+        return null;
+    }
+
+    @Override
+    protected void printLogToConsole(InternalLogLevel level, String msg, Object payload) {
+        // this can only be null when print is called during Tracer construction
+        if (consoleLogCalls != null) {
+            consoleLogCalls.add(new LogCall(level, msg, payload));
+        }
+    }
+
+    boolean consoleLogCallsIsEmpty() {
+        return consoleLogCalls.isEmpty();
+    }
+
+    void resetConsoleLogCalls() {
+        consoleLogCalls.clear();
+    }
+
+    int getNumberOfConsoleLogCalls() {
+        if (consoleLogCallsIsEmpty()) {
+            return 0;
+        }
+        return consoleLogCalls.size();
+    }
+
+    class LogCall {
+        final InternalLogLevel level;
+        final String msg;
+        final Object payload;
+
+        private LogCall(InternalLogLevel level, String msg, Object payload)  {
+            this.level = level;
+            this.msg = msg;
+            this.payload = payload;
+        }
+    }
+}


### PR DESCRIPTION
- Also moved VERBOSITY values to Options because that is the
object they are set on, and so that clients can access the
expected values directly instead of hard-coding from
our Javadoc.