### PR TITLE
Lower-case TextMap keys when extracting them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 <a name="Pending Release"></a>
 ## [Pending Release](https://github.com/lightstep/lightstep-tracer-java/compare/master...0.9.25)
+Bugfix: Handle when SpanContext keys have mixed case like: Ot-tracer-spanId
 
 <a name="0.9.25"></a>
 ## [0.9.25](https://github.com/lightstep/lightstep-tracer-java/compare/0.9.25...0.9.21) (2016-11-18)

--- a/common/src/main/java/com/lightstep/tracer/shared/TextMapPropagator.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/TextMapPropagator.java
@@ -1,6 +1,7 @@
 package com.lightstep.tracer.shared;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import io.opentracing.propagation.TextMap;
@@ -27,8 +28,9 @@ class TextMapPropagator implements Propagator<TextMap> {
         String traceId = null, spanId = null;
         Map<String, String> decodedBaggage = null;
 
+        Locale english = new Locale("en", "US");
         for (Map.Entry<String, String> entry : carrier) {
-            final String key = entry.getKey();
+            final String key = entry.getKey().toLowerCase(english);
             if (FIELD_NAME_TRACE_ID.equals(key)) {
                 requiredFieldCount++;
                 traceId = entry.getValue();

--- a/common/src/test/java/com/lightstep/tracer/shared/TextMapPropagatorTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/TextMapPropagatorTest.java
@@ -1,0 +1,27 @@
+package com.lightstep.tracer.shared;
+
+import io.opentracing.propagation.TextMapExtractAdapter;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import java.util.HashMap;
+import java.util.Map;
+
+public class TextMapPropagatorTest {
+
+    @Test
+    public void testExtract_mixedCaseIsLowered() {
+        Map<String, String> mixedCaseHeaders = new HashMap<>();
+
+        mixedCaseHeaders.put("Ot-tracer-spanid", "spanid");
+        mixedCaseHeaders.put("Ot-tracer-traceId", "traceid");
+        mixedCaseHeaders.put("ot-Tracer-sampled", "true");
+
+        TextMapPropagator subject = new TextMapPropagator();
+
+        SpanContext span = subject.extract(new TextMapExtractAdapter(mixedCaseHeaders));
+
+        assertNotNull(span);
+        assertEquals(span.getSpanId(), "spanid");
+        assertEquals(span.getTraceId(), "traceid");
+    }
+}


### PR DESCRIPTION
Some HTTP transport automatically changes the case of header keys.
Regularizing them to all-lower-case helps us avoid bugs from this.
HTTP spec says that header names are case-insensitive:
https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2