### PR TITLE
Fix dependency scope of maven local publish for jre and common

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 <a name="Pending Release"></a>
 ## [Pending Release](https://github.com/lightstep/lightstep-tracer-java/compare/master...0.9.26)
 
+### BUG FIXES
+* Fixes issue where pom file for java-common and lightstep-tracer-jre (generated during local Maven publish) incorrectly referenced dependencies with 'runtime' scope when it should be 'compile' scope.
+
 <a name="0.9.26"></a>
 ## [0.9.26](https://github.com/lightstep/lightstep-tracer-java/compare/0.9.26...0.9.25)
 Bugfix: Handle when SpanContext keys have mixed case like: Ot-tracer-spanId

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -75,6 +75,14 @@ publishing {
 
             artifact sourcesJar
             artifact javadocJar
+
+            pom.withXml {
+                asNode().dependencies.'*'.findAll() {
+                    it.scope.text() == 'runtime' && project.configurations.compile.allDependencies.find { dep ->
+                        dep.name == it.artifactId.text()
+                    }
+                }.each { it.scope*.value = 'compile'}
+            }
         }
     }
 }

--- a/lightstep-tracer-jre/build.gradle
+++ b/lightstep-tracer-jre/build.gradle
@@ -98,6 +98,13 @@ publishing {
 
             artifact sourcesJar
             artifact javadocJar
+            pom.withXml {
+                asNode().dependencies.'*'.findAll() {
+                    it.scope.text() == 'runtime' && project.configurations.compile.allDependencies.find { dep ->
+                        dep.name == it.artifactId.text()
+                    }
+                }.each { it.scope*.value = 'compile'}
+            }
         }
     }
 }


### PR DESCRIPTION
./gradlew publishToMavenLocal creates poms for both java-common and
lightstep-tracer-jre that reference all dependencies as 'runtime'.
When publishing however we publish them all as 'compile', which
is the desired scope.

I found this article about how to fix it:
https://discuss.gradle.org/t/maven-publish-plugin-generated-pom-making-dependency-scope-runtime/7494

Although very old, it still seems relevant and works for us.

This change has no effect on the published artifacts in bintray and Maven
central, only on the artifacts if published locally.