### PR TITLE
Fix ClassCastException on inject of non-LightStep SpanContext

### DIFF
--- a/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/AbstractTracer.java
@@ -280,6 +280,10 @@ public abstract class AbstractTracer implements Tracer {
     }
 
     public <C> void inject(io.opentracing.SpanContext spanContext, Format<C> format, C carrier) {
+        if ( !(spanContext instanceof SpanContext) ) {
+            error("Unsupported SpanContext implementation: " + spanContext.getClass());
+            return;
+        }
         SpanContext lightstepSpanContext = (SpanContext) spanContext;
         if (format == Format.Builtin.TEXT_MAP) {
             Propagator.TEXT_MAP.inject(lightstepSpanContext, (TextMap) carrier);

--- a/common/src/main/java/com/lightstep/tracer/shared/TextMapPropagator.java
+++ b/common/src/main/java/com/lightstep/tracer/shared/TextMapPropagator.java
@@ -8,11 +8,11 @@ import io.opentracing.propagation.TextMap;
 
 class TextMapPropagator implements Propagator<TextMap> {
     private static final String PREFIX_TRACER_STATE = "ot-tracer-";
-    private static final String PREFIX_BAGGAGE = "ot-baggage-";
+    static final String PREFIX_BAGGAGE = "ot-baggage-";
 
-    private static final String FIELD_NAME_TRACE_ID = PREFIX_TRACER_STATE + "traceid";
-    private static final String FIELD_NAME_SPAN_ID = PREFIX_TRACER_STATE + "spanid";
-    private static final String FIELD_NAME_SAMPLED = PREFIX_TRACER_STATE + "sampled";
+    static final String FIELD_NAME_TRACE_ID = PREFIX_TRACER_STATE + "traceid";
+    static final String FIELD_NAME_SPAN_ID = PREFIX_TRACER_STATE + "spanid";
+    static final String FIELD_NAME_SAMPLED = PREFIX_TRACER_STATE + "sampled";
 
     public void inject(SpanContext spanContext, final TextMap carrier) {
         carrier.put(FIELD_NAME_TRACE_ID, spanContext.getTraceId());

--- a/common/src/test/java/com/lightstep/tracer/shared/AbstractTracerTest.java
+++ b/common/src/test/java/com/lightstep/tracer/shared/AbstractTracerTest.java
@@ -1,21 +1,70 @@
 package com.lightstep.tracer.shared;
 
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Map;
+
+import io.opentracing.SpanContext;
+import io.opentracing.propagation.Format;
+import io.opentracing.propagation.TextMap;
 
 import static com.lightstep.tracer.shared.Options.VERBOSITY_DEBUG;
 import static com.lightstep.tracer.shared.Options.VERBOSITY_ERRORS_ONLY;
 import static com.lightstep.tracer.shared.Options.VERBOSITY_FIRST_ERROR_ONLY;
 import static com.lightstep.tracer.shared.Options.VERBOSITY_INFO;
 import static com.lightstep.tracer.shared.Options.VERBOSITY_NONE;
+import static com.lightstep.tracer.shared.TextMapPropagator.FIELD_NAME_SAMPLED;
+import static com.lightstep.tracer.shared.TextMapPropagator.FIELD_NAME_SPAN_ID;
+import static com.lightstep.tracer.shared.TextMapPropagator.FIELD_NAME_TRACE_ID;
+import static com.lightstep.tracer.shared.TextMapPropagator.PREFIX_BAGGAGE;
+import static io.opentracing.propagation.Format.Builtin.BINARY;
+import static io.opentracing.propagation.Format.Builtin.HTTP_HEADERS;
+import static io.opentracing.propagation.Format.Builtin.TEXT_MAP;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
+@RunWith(MockitoJUnitRunner.class)
 public class AbstractTracerTest {
 
     private static final String ACCESS_TOKEN = "abc123";
     private static final String TEST_MSG = "hello tracer";
+    private static final String TRACE_ID = "my-trace-id";
+    private static final String SPAN_ID = "my-span-id";
+    private static final String BAGGAGE_KEY = "baggage-key";
+    private static final String BAGGAGE_VALUE = "baggage-value";
+
+    @Mock
+    private SpanContext invalidSpanContext;
+
+    @Mock
+    private TextMap textMap;
+
+    @Mock
+    private TextMap httpHeaders;
+
+    @Mock
+    private ByteBuffer byteBuffer;
+
+    @Mock
+    private Format<Object> genericFormat;
+
+    private com.lightstep.tracer.shared.SpanContext spanContext;
+
+    @Before
+    public void setup() {
+        Map<String, String> baggage = Collections.singletonMap(BAGGAGE_KEY, BAGGAGE_VALUE);
+        spanContext = new com.lightstep.tracer.shared.SpanContext(TRACE_ID, SPAN_ID, baggage);
+    }
 
     /**
      * Provides an implementation of AbstractTracer (for use in testing) that is configured to
@@ -123,5 +172,54 @@ public class AbstractTracerTest {
         String expectedUrlStart = "https://app.lightstep.com/" + ACCESS_TOKEN + "/trace?span_guid="
                 + spanId + "&at_micros=";
         assertTrue("Unexpected trace url: " + result, result.startsWith(expectedUrlStart));
+    }
+
+    /**
+     * Ensures that if an invalid spanContext is passed to inject, that no ClassCastException is
+     * thrown, instead an error is logged and the carrier injection is skipped.
+     */
+    @Test
+    public void testInject_invalidSpanContextType() throws Exception {
+        StubTracer undertest = createTracer(VERBOSITY_ERRORS_ONLY);
+        undertest.inject(invalidSpanContext, TEXT_MAP, textMap);
+        verifyZeroInteractions(textMap);
+    }
+
+    @Test
+    public void testInject_textMap() throws Exception {
+        StubTracer undertest = createTracer(VERBOSITY_ERRORS_ONLY);
+        undertest.inject(spanContext, TEXT_MAP, textMap);
+        verify(textMap).put(FIELD_NAME_TRACE_ID, TRACE_ID);
+        verify(textMap).put(FIELD_NAME_SPAN_ID, SPAN_ID);
+        verify(textMap).put(FIELD_NAME_SAMPLED, "true");
+        verify(textMap).put(PREFIX_BAGGAGE + BAGGAGE_KEY, BAGGAGE_VALUE);
+    }
+
+    @Test
+    public void testInject_httpHeaders() throws Exception {
+        StubTracer undertest = createTracer(VERBOSITY_ERRORS_ONLY);
+        undertest.inject(spanContext, HTTP_HEADERS, httpHeaders);
+        verify(httpHeaders).put(FIELD_NAME_TRACE_ID, TRACE_ID);
+        verify(httpHeaders).put(FIELD_NAME_SPAN_ID, SPAN_ID);
+        verify(httpHeaders).put(FIELD_NAME_SAMPLED, "true");
+        verify(httpHeaders).put(PREFIX_BAGGAGE + BAGGAGE_KEY, BAGGAGE_VALUE);
+    }
+
+    @Test
+    public void testInject_binary() throws Exception {
+        StubTracer undertest = createTracer(VERBOSITY_ERRORS_ONLY);
+        undertest.inject(spanContext, BINARY, byteBuffer);
+
+        verifyZeroInteractions(byteBuffer);
+    }
+
+    /**
+     * Ensures that no exception are thrown if an unsupported Format type is provided.
+     */
+    @Test
+    public void testInject_unsupportedFormat() throws Exception {
+        StubTracer undertest = createTracer(VERBOSITY_ERRORS_ONLY);
+        undertest.inject(spanContext, genericFormat, textMap);
+        verifyZeroInteractions(textMap);
     }
 }


### PR DESCRIPTION
Instead of throwing a ClassCastException, log an error with the
name of the invalid class and move-on.