### PR TITLE
Make building android library optional (if Android SDK is installed)

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,9 +1,13 @@
 rootProject.name = 'lightstep-tracer-java'
 
-include 'lightstep-tracer-jre'
-include 'lightstep-tracer-android'
 include "java-common"
 project(":java-common").projectDir = file("common")
+
+include 'lightstep-tracer-jre'
 include 'examples:jre-simple'
-include 'examples:android-demo'
-include 'examples:android-simple'
+
+if (System.getenv()['ANDROID_HOME']) {
+    include 'lightstep-tracer-android'
+    include 'examples:android-demo'
+    include 'examples:android-simple'
+}


### PR DESCRIPTION
Currently a default build will fail if one does not have the Android SDK installed, make building android libraries optional by detecting whether ANDROID_HOME is set.