### PR TITLE
Add Profile field in Benchmark client

### DIFF
--- a/lightstep-tracer-jre/src/benchmark/java/com/lightstep/benchmark/BenchmarkClient.java
+++ b/lightstep-tracer-jre/src/benchmark/java/com/lightstep/benchmark/BenchmarkClient.java
@@ -53,6 +53,7 @@ class BenchmarkClient {
         public long NumLogs;
         public boolean Trace;
         public boolean Exit;
+        public boolean Profile;
     }
 
     private static class Result {


### PR DESCRIPTION
Add new Profile field in order for lightstep-benchmarks to work with this client lib.