### PR TITLE
Add slf4j-simple to the pom.xml

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -33,6 +33,11 @@
             <artifactId>lightstep-tracer-jre</artifactId>
             <version>0.12.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.21</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>com.lightstep.tracer</groupId>

--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -106,6 +106,12 @@
             <version>1.7.21</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.25</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
             <version>1.2.0</version>


### PR DESCRIPTION
The benchmark (and junit tests) have errors in the logs...

SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

Because no slf4j implementation is provided. Set a default in
the lightstep-tracer-jre/pom.xml but make it provided so that clients
can choose their own implementation.

In examples and benchmark, include slf4j-simple with the jar.