### PR TITLE
Move shadow to its own maven module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ local.properties
 build
 **/*.iml
 target
+dependency-reduced-pom.xml
+

--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -24,50 +24,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <shadedClassifierName>shadow</shadedClassifierName>
-                            <createSourcesJar>true</createSourcesJar>
-                            <shadeSourcesContent>true</shadeSourcesContent>
-                            <artifactSet>
-                                <excludes>
-                                    <exclude>org.slf4j:slf4j-api</exclude>
-                                    <exclude>io.opentracing</exclude>
-                                    <exclude>com.lightstep.tracer:java-common</exclude>
-                                </excludes>
-                            </artifactSet>
-                            <relocations>
-                                <relocation>
-                                    <pattern>com.google</pattern>
-                                    <shadedPattern>lightstep.com.google</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>google.protobuf</pattern>
-                                    <shadedPattern>lightstep.google.protobuf</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>io.netty</pattern>
-                                    <shadedPattern>lightstep.io.netty</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>javax.annotation</pattern>
-                                    <shadedPattern>lightstep.javax.annotation</shadedPattern>
-                                </relocation>
-                            </relocations>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -44,5 +44,6 @@
         <module>lightstep-tracer-jre</module>
         <module>examples</module>
         <module>benchmark</module>
+        <module>shadow</module>
     </modules>
 </project>

--- a/shadow/pom.xml
+++ b/shadow/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>lightstep-tracer-jre-shadow</artifactId>
+    <packaging>jar</packaging>
+
+    <parent>
+        <artifactId>lightstep-tracer-java</artifactId>
+        <groupId>com.lightstep.tracer</groupId>
+        <version>0.12.6</version>
+    </parent>
+
+    <distributionManagement>
+        <repository>
+            <id>lightstep-bintray</id>
+            <url>https://api.bintray.com/maven/lightstep/maven/lightstep-tracer-jre/;publish=1</url>
+        </repository>
+    </distributionManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <includeDependencySources>true</includeDependencySources>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <createSourcesJar>true</createSourcesJar>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>org.slf4j:slf4j-api</exclude>
+                                    <exclude>io.opentracing</exclude>
+                                    <exclude>com.lightstep.tracer:java-common</exclude>
+                                    <exclude>org.apache.tomcat:tomcat-jni</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>com.google</pattern>
+                                    <shadedPattern>lightstep.com.google</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>google.protobuf</pattern>
+                                    <shadedPattern>lightstep.google.protobuf</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>io.netty</pattern>
+                                    <shadedPattern>lightstep.io.netty</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>javax.annotation</pattern>
+                                    <shadedPattern>lightstep.javax.annotation</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.lightstep.tracer</groupId>
+            <artifactId>lightstep-tracer-jre</artifactId>
+            <version>0.12.6</version>
+        </dependency>
+    </dependencies>
+
+</project>


### PR DESCRIPTION
- This enables us to generate a dependency reduced pom to package
with the jar
- Also fixes issue with the 0.12.6 published version where the shadow jar was a classifier instead of being its own artifact