### PR TITLE
Fix IDE warnings from IntelliJ

### DIFF
--- a/benchmark/src/main/java/com/lightstep/benchmark/BenchmarkClient.java
+++ b/benchmark/src/main/java/com/lightstep/benchmark/BenchmarkClient.java
@@ -14,6 +14,8 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 class BenchmarkClient {
     private static final long PRIME_WORK = 982451653;
@@ -52,7 +54,6 @@ class BenchmarkClient {
         public long NumLogs;
         public boolean Trace;
         public boolean Exit;
-        public boolean Profile;
     }
 
     private static class Result {
@@ -80,8 +81,8 @@ class BenchmarkClient {
         }
     }
 
-    private <T> T postGetJson(String path, Class<T> cl) {
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(getUrlReader(path)))) {
+    private <T> T postGetJson(Class<T> cl) {
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(getUrlReader("/control")))) {
             return objectMapper.readValue(br, cl);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -89,19 +90,19 @@ class BenchmarkClient {
     }
 
     private Control getControl() {
-        return postGetJson("/control", Control.class);
+        return postGetJson(Control.class);
     }
 
     private void postResult(Result r) {
-        StringBuilder rurl = new StringBuilder("/result?timing=");
-        rurl.append(r.runTime);
-        rurl.append("&flush=");
-        rurl.append(r.flushTime);
-        rurl.append("&s=");
-        rurl.append(r.sleepNanos / 1e9);
-        rurl.append("&a=");
-        rurl.append(r.answer);
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(getUrlReader(rurl.toString())))) {
+        String rurl = "/result?timing=" + r.runTime +
+                "&flush=" +
+                r.flushTime +
+                "&s=" +
+                r.sleepNanos / 1e9 +
+                "&a=" +
+                r.answer;
+        //noinspection EmptyTryBlock
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(getUrlReader(rurl)))) {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -122,11 +123,14 @@ class BenchmarkClient {
         long sleepDebt = 0;
 
         for (long i = 0; i < c.Repeat; i++) {
-            Span span = t.buildSpan("span/test").start();
+            Span span = t.buildSpan("span/test").startManual();
             r.answer = work(c.Work);
 
             for (long l = 0; l < c.NumLogs; l++) {
-                span.log("testlog", LOG_PAYLOAD_STR.substring(0, (int) c.BytesPerLog));
+                Map<String,Object> log = new HashMap<>();
+                log.put("message", "testlog");
+                log.put("payload", LOG_PAYLOAD_STR.substring(0, (int) c.BytesPerLog));
+                span.log(log);
             }
 
             span.finish();


### PR DESCRIPTION
These were mostly around use of deprecated methods.

.start() is now .startManual()

.log(String, Object) is now .log(Map)