### PR TITLE
Make benchmark.jar an uber jar

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -12,6 +12,28 @@
         <artifactId>lightstep-tracer-java</artifactId>
         <version>0.12.6</version>
     </parent>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>io.opentracing</groupId>


### PR DESCRIPTION
Gradle used to do this, and it is required for the lightstep-benchmark
project in order to have all the necessary classes in the classpath.