### PR TITLE
upgrade java-common to 0.13.1

### DIFF
--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>java-common</artifactId>
-            <version>0.13.0</version>
+            <version>0.13.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This version contains fixes to avoid a deadlock seen while
waiting for collector response.