### PR TITLE
Upgrade java-common to 0.13.2

### DIFF
--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>java-common</artifactId>
-            <version>0.13.1</version>
+            <version>0.13.2</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Addresses major issue with GRPC call deadline. Previous version was
setting a single global deadline, so all calls after 30s would
exceed the deadline. This new version sets a 30s deadline from the time
of each call.