### PR TITLE
Publish parent pom because lightstep-tracer-jre pom references it

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.10</version>
+        <version>0.12.11</version>
     </parent>
 
     <build>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.10</version>
+            <version>0.12.11</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.11</version>
+        <version>0.12.12</version>
     </parent>
 
     <build>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.11</version>
+            <version>0.12.12</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.13</version>
+        <version>0.12.14</version>
     </parent>
 
     <build>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.13</version>
+            <version>0.12.14</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.12</version>
+        <version>0.12.13</version>
     </parent>
 
     <build>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.12</version>
+            <version>0.12.13</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.12</version>
+        <version>0.12.13</version>
     </parent>
 
     <build>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.12</version>
+            <version>0.12.13</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.10</version>
+        <version>0.12.11</version>
     </parent>
 
     <build>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.10</version>
+            <version>0.12.11</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.11</version>
+        <version>0.12.12</version>
     </parent>
 
     <build>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.11</version>
+            <version>0.12.12</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.13</version>
+        <version>0.12.14</version>
     </parent>
 
     <build>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.13</version>
+            <version>0.12.14</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/inc-version.sh
+++ b/inc-version.sh
@@ -39,7 +39,7 @@ git push --tags
 echo "Updated from $CURRENT_VERSION to $NEW_VERSION"
 
 # Build and deploy to Bintray
-mvn deploy -pl lightstep-tracer-jre
+mvn deploy -pl .,lightstep-tracer-jre
 
 # Sign the jar and other files in Bintray
 curl -H "X-GPG-PASSPHRASE:$BINTRAY_GPG_PASSPHRASE" -u $BINTRAY_USER:$BINTRAY_API_KEY -X POST https://api.bintray.com/gpg/lightstep/maven/lightstep-tracer-jre/versions/$NEW_VERSION

--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -13,13 +13,6 @@
         <version>0.12.10</version>
     </parent>
 
-    <distributionManagement>
-        <repository>
-            <id>lightstep-bintray</id>
-            <url>https://api.bintray.com/maven/lightstep/maven/lightstep-tracer-jre/;publish=1</url>
-        </repository>
-    </distributionManagement>
-
     <build>
         <plugins>
             <plugin>

--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.12</version>
+        <version>0.12.13</version>
     </parent>
 
     <build>

--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.13</version>
+        <version>0.12.14</version>
     </parent>
 
     <build>

--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.11</version>
+        <version>0.12.12</version>
     </parent>
 
     <build>

--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.10</version>
+        <version>0.12.11</version>
     </parent>
 
     <build>

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/Version.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/Version.java
@@ -1,5 +1,5 @@
 package com.lightstep.tracer.jre;
 
 class Version {
-    static final String LIGHTSTEP_TRACER_VERSION = "0.12.10";
+    static final String LIGHTSTEP_TRACER_VERSION = "0.12.11";
 }

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/Version.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/Version.java
@@ -1,5 +1,5 @@
 package com.lightstep.tracer.jre;
 
 class Version {
-    static final String LIGHTSTEP_TRACER_VERSION = "0.12.13";
+    static final String LIGHTSTEP_TRACER_VERSION = "0.12.14";
 }

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/Version.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/Version.java
@@ -1,5 +1,5 @@
 package com.lightstep.tracer.jre;
 
 class Version {
-    static final String LIGHTSTEP_TRACER_VERSION = "0.12.12";
+    static final String LIGHTSTEP_TRACER_VERSION = "0.12.13";
 }

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/Version.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/Version.java
@@ -1,5 +1,5 @@
 package com.lightstep.tracer.jre;
 
 class Version {
-    static final String LIGHTSTEP_TRACER_VERSION = "0.12.11";
+    static final String LIGHTSTEP_TRACER_VERSION = "0.12.12";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.lightstep.tracer</groupId>
     <artifactId>lightstep-tracer-java</artifactId>
     <packaging>pom</packaging>
-    <version>0.12.12</version>
+    <version>0.12.13</version>
 
     <name>LightStep Tracer Java (parent)</name>
     <description>LightStep Tracer Java (parent)</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.lightstep.tracer</groupId>
     <artifactId>lightstep-tracer-java</artifactId>
     <packaging>pom</packaging>
-    <version>0.12.13</version>
+    <version>0.12.14</version>
 
     <name>LightStep Tracer Java (parent)</name>
     <description>LightStep Tracer Java (parent)</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.lightstep.tracer</groupId>
     <artifactId>lightstep-tracer-java</artifactId>
     <packaging>pom</packaging>
-    <version>0.12.10</version>
+    <version>0.12.11</version>
 
     <name>LightStep Tracer Java (parent)</name>
     <description>LightStep Tracer Java (parent)</description>

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,10 @@
     <packaging>pom</packaging>
     <version>0.12.10</version>
 
+    <name>LightStep Tracer Java (parent)</name>
+    <description>LightStep Tracer Java (parent)</description>
+    <url>https://github.com/lightstep/lightstep-tracer-java</url>
+
     <organization>
         <name>LightStep</name>
         <url>http://lightstep.com/</url>
@@ -34,6 +38,13 @@
         <developerConnection>https://github.com/lightstep/lightstep-tracer-java</developerConnection>
         <url>https://github.com/lightstep/lightstep-tracer-java</url>
     </scm>
+
+    <distributionManagement>
+        <repository>
+            <id>lightstep-bintray</id>
+            <url>https://api.bintray.com/maven/lightstep/maven/lightstep-tracer-jre/;publish=1</url>
+        </repository>
+    </distributionManagement>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.lightstep.tracer</groupId>
     <artifactId>lightstep-tracer-java</artifactId>
     <packaging>pom</packaging>
-    <version>0.12.11</version>
+    <version>0.12.12</version>
 
     <name>LightStep Tracer Java (parent)</name>
     <description>LightStep Tracer Java (parent)</description>

--- a/shadow/pom.xml
+++ b/shadow/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>lightstep-tracer-java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.12.12</version>
+        <version>0.12.13</version>
     </parent>
 
     <distributionManagement>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.12</version>
+            <version>0.12.13</version>
         </dependency>
     </dependencies>
 

--- a/shadow/pom.xml
+++ b/shadow/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>lightstep-tracer-java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.12.11</version>
+        <version>0.12.12</version>
     </parent>
 
     <distributionManagement>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.11</version>
+            <version>0.12.12</version>
         </dependency>
     </dependencies>
 

--- a/shadow/pom.xml
+++ b/shadow/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>lightstep-tracer-java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.12.13</version>
+        <version>0.12.14</version>
     </parent>
 
     <distributionManagement>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.13</version>
+            <version>0.12.14</version>
         </dependency>
     </dependencies>
 

--- a/shadow/pom.xml
+++ b/shadow/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>lightstep-tracer-java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.12.10</version>
+        <version>0.12.11</version>
     </parent>
 
     <distributionManagement>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.10</version>
+            <version>0.12.11</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Addresses issue #121 