### PR TITLE
upgraded to io.opentracing 0.31.0-RC1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 <a name="Pending Release"></a>
 ## [Pending Release](https://github.com/lightstep/lightstep-tracer-java/compare/master...0.12.15)
 
+<a name="0.12.16-RC1"></a>
+## [0.12.16-RC1](https://github.com/lightstep/lightstep-tracer-java/compare/0.12.16-RC1...0.12.15)
+* Upgraded to io.opentracing 0.31.0-RC1
+
 <a name="0.12.15"></a>
 ## [0.12.15](https://github.com/lightstep/lightstep-tracer-java/compare/0.12.14...0.12.15)
 * Fixed issue where shadow jar was not published to Maven

--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.15</version>
+        <version>0.12.16-RC1</version>
     </parent>
 
     <build>
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.15</version>
+            <version>0.12.16-RC1</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/benchmark/src/main/java/com/lightstep/benchmark/BenchmarkClient.java
+++ b/benchmark/src/main/java/com/lightstep/benchmark/BenchmarkClient.java
@@ -3,7 +3,7 @@ package com.lightstep.benchmark;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.lightstep.tracer.jre.JRETracer;
 import com.lightstep.tracer.shared.Options;
-import io.opentracing.NoopTracerFactory;
+import io.opentracing.noop.NoopTracerFactory;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.15</version>
+        <version>0.12.16-RC1</version>
     </parent>
 
     <build>
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.15</version>
+            <version>0.12.16-RC1</version>
         </dependency>
         <dependency>
             <groupId>io.opentracing</groupId>

--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.lightstep.tracer</groupId>
         <artifactId>lightstep-tracer-java</artifactId>
-        <version>0.12.15</version>
+        <version>0.12.16-RC1</version>
     </parent>
 
     <build>
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>java-common</artifactId>
-            <version>0.13.2</version>
+            <version>0.13.3-RC1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/Version.java
+++ b/lightstep-tracer-jre/src/main/java/com/lightstep/tracer/jre/Version.java
@@ -1,5 +1,5 @@
 package com.lightstep.tracer.jre;
 
 class Version {
-    static final String LIGHTSTEP_TRACER_VERSION = "0.12.15";
+    static final String LIGHTSTEP_TRACER_VERSION = "0.12.16-RC1";
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.lightstep.tracer</groupId>
     <artifactId>lightstep-tracer-java</artifactId>
     <packaging>pom</packaging>
-    <version>0.12.15</version>
+    <version>0.12.16-RC1</version>
 
     <name>LightStep Tracer Java (parent)</name>
     <description>LightStep Tracer Java (parent)</description>
@@ -50,7 +50,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <org.slf4j.version>1.7.25</org.slf4j.version>
-        <io.opentracing.version>0.30.0</io.opentracing.version>
+        <io.opentracing.version>0.31.0-RC1</io.opentracing.version>
         <io.grpc.version>1.4.0</io.grpc.version>
         <io.netty.version>2.0.5.Final</io.netty.version>
     </properties>

--- a/shadow/pom.xml
+++ b/shadow/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>lightstep-tracer-java</artifactId>
         <groupId>com.lightstep.tracer</groupId>
-        <version>0.12.15</version>
+        <version>0.12.16-RC1</version>
     </parent>
 
     <distributionManagement>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>com.lightstep.tracer</groupId>
             <artifactId>lightstep-tracer-jre</artifactId>
-            <version>0.12.15</version>
+            <version>0.12.16-RC1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
it fails because it depends on

<dependency>
            <groupId>com.lightstep.tracer</groupId>
            <artifactId>java-common</artifactId>
            <version>0.13.3-RC1</version>
</dependency>
which is not released (PR: lightstep/lightstep-tracer-java-common#13)