### PR TITLE
Remove javadoc plugin from runtime dependencies

### DIFF
--- a/lightstep-tracer-jre/pom.xml
+++ b/lightstep-tracer-jre/pom.xml
@@ -89,14 +89,6 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-javadoc-plugin -->
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.0.1</version>
-        </dependency>
-
     </dependencies>
 
 </project>


### PR DESCRIPTION
I guess the javadoc maven plugin was added accidentally to the runtime dependencies, it was pulling lots of transitive dependencies, one of them was struts that scared me a lot.