### PR TITLE
[minor] Removing `this.` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Tracer tracer = new com.lightstep.tracer.jre.JRETracer(
 );
 
 // Start and finish a Span
-Span span = this.tracer.buildSpan("my_span").start();
+Span span = tracer.buildSpan("my_span").start();
 this.doSomeWorkHere();
 span.finish();
 ```


### PR DESCRIPTION
Removing the superfluous `this.` so that it's easier to copy&paste the example.