### PR TITLE
Update jackson-databind to 2.9.8

### DIFF
--- a/benchmark/pom.xml
+++ b/benchmark/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.5</version>
+            <version>2.9.8</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
2.9.8 is patched against a recently
found vulnerability.