### PR TITLE
Remove slf4j-simple from our bundle jar.

### DIFF
--- a/lightstep-tracer-jre-bundle/pom.xml
+++ b/lightstep-tracer-jre-bundle/pom.xml
@@ -47,11 +47,6 @@
         <artifactId>opentracing-tracerresolver</artifactId>
         <version>${tracerresolver.version}</version>
       </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>${org.slf4j.version}</version>
-      </dependency>
 
       <!-- Test dependencies -->
       <dependency>


### PR DESCRIPTION
It prevents its use along Spring.