### PR TITLE
update readme to mark http as default and recommended configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,27 +26,15 @@ additional installation and setup information for using the library with various
     <artifactId>lightstep-tracer-jre</artifactId>
     <version> VERSION </version>
 </dependency>
-
 <dependency>
-    <groupId>com.lightstep.tracer</groupId>
-    <artifactId>tracer-grpc</artifactId>
-    <version> TRACER-GRPC-VERSION </version>
+   <groupId>com.lightstep.tracer</groupId>
+   <artifactId>tracer-okhttp</artifactId>
+   <version> VERSION </version>
 </dependency>
-
 <dependency>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-simple</artifactId>
     <version>1.7.25</version>
-</dependency>
-<dependency>
-    <groupId>io.grpc</groupId>
-    <artifactId>grpc-netty</artifactId>
-    <version>1.14.0</version>
-</dependency>
-<dependency>
-    <groupId>io.netty</groupId>
-    <artifactId>netty-tcnative-boringssl-static</artifactId>
-    <version>2.0.12.Final</version>
 </dependency>
 ```
 
@@ -63,10 +51,8 @@ repositories {
 }
 dependencies {
     compile 'com.lightstep.tracer:lightstep-tracer-jre:VERSION'
-    compile 'com.lightstep.tracer:tracer-grpc:VERSION'
+    compile 'com.lightstep.tracer:tracer-okhttp:VERSION'
     compile 'org.sl4j:sl4j-simple:1.7.25'
-    compile 'io.grpc:grpc-netty:1.14.0'
-    compile 'io.netty:netty-tcnative-boringssl-static:2.0.12.Final'
 }
 ```
 
@@ -156,14 +142,14 @@ options = new com.lightstep.tracer.shared.Options.OptionsBuilder()
 
 ### Advanced Option: Transport and Serialization Protocols
 
-By following the above configuration, the tracer will send information to LightStep using GRPC and Protocol Buffers which is the recommended configuration. If there are no specific transport protocol needs you have, there is no need to change this default.
+By following the above configuration, the tracer will send information to LightStep using HTTP and Protocol Buffers which is the recommended configuration. If there are no specific transport protocol needs you have, there is no need to change this default.
 
 There are two options for transport protocols:
 
-- [Protocol Buffers](https://developers.google.com/protocol-buffers/) over [GRPC](https://grpc.io/) - The recommended, default, and most performant solution.
-- [Protocol Buffers](https://developers.google.com/protocol-buffers/) over HTTP using [OkHttp](http://square.github.io/okhttp/) - New transport protocol supported for use cases where GRPC isn't an option. In order to enable HTTP you will need to configure the LightStep collectors receiving the data to accept HTTP traffic. Reach out to LightStep for support in this.
+- [Protocol Buffers](https://developers.google.com/protocol-buffers/) over HTTP using [OkHttp](http://square.github.io/okhttp/) - The recommended and default solution.
+- [Protocol Buffers](https://developers.google.com/protocol-buffers/) over [GRPC](https://grpc.io/) - This is a more advanced solution that might be desirable if you already have gRPC networking configured.
 
-You can configure the tracer to support HTTP by replacing `com.lightstep.tracer:tracer-grpc` with `com.lightstep.tracer:tracer-okhttp` when including the tracer dependency. i.e.
+You can configure the tracer to support gRPC by replacing `com.lightstep.tracer:tracer-okhttp` with `com.lightstep.tracer:tracer-grpc` when including the tracer dependency and including a grpc dependency. i.e.
 
 #### Maven 
 
@@ -173,11 +159,20 @@ You can configure the tracer to support HTTP by replacing `com.lightstep.tracer:
   <artifactId>lightstep-tracer-jre</artifactId>
   <version> VERSION </version>
 </dependency>
-
 <dependency>
    <groupId>com.lightstep.tracer</groupId>
-   <artifactId>tracer-okhttp</artifactId>
+   <artifactId>tracer-grpc</artifactId>
    <version> VERSION </version>
+</dependency>
+<dependency>
+    <groupId>io.grpc</groupId>
+    <artifactId>grpc-netty</artifactId>
+    <version>1.14.0</version>
+</dependency>
+<dependency>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-tcnative-boringssl-static</artifactId>
+    <version>2.0.12.Final</version>
 </dependency>
 ```
 
@@ -189,7 +184,9 @@ repositories {
 }
 dependencies {
     compile 'com.lightstep.tracer:lightstep-tracer-jre:VERSION'
-    compile 'com.lightstep.tracer:tracer-okhttp:VERSION'
+    compile 'com.lightstep.tracer:tracer-grpc:VERSION'
+    compile 'io.grpc:grpc-netty:1.14.0'
+    compile 'io.netty:netty-tcnative-boringssl-static:2.0.12.Final'
 }
 ```
 


### PR DESCRIPTION
R: @aliceadelef @ltyson 

CC: @lightstep/team-observability @lightstep/team-application-developer

### Summary of Change

This updates the readme to mark http as the default transport protocol (replacing grpc). This should make it easier to get up and running the java tracer without needing grpc networking infrastructure.