### PR TITLE
Set dependencies to scope=provided

### DIFF
--- a/lightstep-tracer-jre-bundle/assembly.xml
+++ b/lightstep-tracer-jre-bundle/assembly.xml
@@ -1,0 +1,24 @@
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+  <id>jar-with-dependencies</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <unpack>true</unpack>
+      <scope>provided</scope>
+    </dependencySet>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <unpack>true</unpack>
+      <scope>runtime</scope>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/lightstep-tracer-jre-bundle/pom.xml
+++ b/lightstep-tracer-jre-bundle/pom.xml
@@ -31,21 +31,25 @@
         <groupId>${project.groupId}</groupId>
         <artifactId>lightstep-tracer-jre</artifactId>
         <version>0.16.1</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>tracer-okhttp</artifactId>
         <version>${lightstep.parent.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>io.opentracing</groupId>
         <artifactId>opentracing-api</artifactId>
         <version>${io.opentracing.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentracing-tracerresolver</artifactId>
         <version>${tracerresolver.version}</version>
+        <scope>provided</scope>
       </dependency>
 
       <!-- Test dependencies -->
@@ -60,15 +64,21 @@
     <build>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-shade-plugin</artifactId>
-          <version>3.2.1</version>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>3.1.1</version>
           <executions>
             <execution>
+              <id>jar-with-dependencies</id>
               <phase>package</phase>
               <goals>
-                <goal>shade</goal>
+                <goal>single</goal>
               </goals>
+              <configuration>
+                <descriptors>
+                  <descriptor>assembly.xml</descriptor>
+                </descriptors>
+                <appendAssemblyId>false</appendAssemblyId>
+              </configuration>
             </execution>
           </executions>
         </plugin>


### PR DESCRIPTION
Currently, the dependency graph of `lightstep-tracer-jre-bundle` includes its dependencies in scope=compile. When an upstream dependent of `lightstep-tracer-jre-bundle` analyzes its dependency graph, the graph will include each of these dependencies with scope=compile. However, the `lightstep-tracer-jre-bundle` is a "fat-jar" shaded bundle, which includes all of the classes of its dependencies inside it. Therefore, the original dependencies _should not_ be on the dependency graph.

The SpecialAgent is an upstream dependent of `lightstep-tracer-jre-bundle`, and analyzes the dependency graph of its dependencies to determine which JARs need to be bundled with the SpecialAgent. Since the `lightstep-tracer-jre-bundle` declares its dependencies with scope=compile, the SpecialAgent includes these JARs, unnecessarily.

This PR fixes the dependency graph for `lightstep-tracer-jre-bundle` by declaring its dependencies as scope=provided, and using a different mechanism to create the shaded "uber-jar" (because the `maven-shade-plugin` does not have a mechanism to shade dependencies with scope=provided, but the `maven-assembly-plugin` does).