### PR TITLE
Exclude OT dependencies from assembly

### DIFF
--- a/lightstep-tracer-jre-bundle/assembly.xml
+++ b/lightstep-tracer-jre-bundle/assembly.xml
@@ -13,6 +13,10 @@
       <useProjectArtifact>true</useProjectArtifact>
       <unpack>true</unpack>
       <scope>provided</scope>
+      <excludes>
+        <exclude>io.opentracing:opentracing-api</exclude>
+        <exclude>io.opentracing.contrib:opentracing-tracerresolver</exclude>
+      </excludes>
     </dependencySet>
     <dependencySet>
       <outputDirectory>/</outputDirectory>

--- a/lightstep-tracer-jre-bundle/assembly.xml
+++ b/lightstep-tracer-jre-bundle/assembly.xml
@@ -15,6 +15,8 @@
       <scope>provided</scope>
       <excludes>
         <exclude>io.opentracing:opentracing-api</exclude>
+        <exclude>io.opentracing:opentracing-util</exclude>
+        <exclude>io.opentracing:opentracing-noop</exclude>
         <exclude>io.opentracing.contrib:opentracing-tracerresolver</exclude>
       </excludes>
     </dependencySet>

--- a/lightstep-tracer-jre-bundle/pom.xml
+++ b/lightstep-tracer-jre-bundle/pom.xml
@@ -30,7 +30,7 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>lightstep-tracer-jre</artifactId>
-        <version>0.16.2</version>
+        <version>${project.version}</version>
         <scope>provided</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
This PR removes the OT dependencies from the assembly. The problem this solves is as follows:

The LightStep Tracer Plugin is a plugin that is intended to be "plugged in" to an environment that provides the necessary OT APIs. Since the LightStep Tracer Plugin currently includes all of these APIs by itself, the presence of these classes on the classpath end up masking the classes included by the hosting environment. With the release of OT API 0.32.0 and 0.33.0, masked classes end up breaking due to version mismatches, since `${io.opentracing.version}` is set to 0.32.0 for LightStep Tracer.