### PR TITLE
Revert the netty version update.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <lightstep.parent.version>0.18.0</lightstep.parent.version>
         <io.opentracing.version>0.33.0</io.opentracing.version>
         <io.grpc.version>1.11.0</io.grpc.version>
-        <io.netty.version>2.0.25.Final</io.netty.version>
+        <io.netty.version>2.0.8.Final</io.netty.version>
         <tracerresolver.version>0.1.8</tracerresolver.version>
     </properties>
 


### PR DESCRIPTION
Rever the netty update for now, as updating it
requires also updating grpc/protobuf, or otherwise
it will cause runtime problems.