### PR TITLE
Update java common to 0.19.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <org.slf4j.version>1.7.25</org.slf4j.version>
-        <lightstep.parent.version>0.19.1</lightstep.parent.version>
+        <lightstep.parent.version>0.19.2</lightstep.parent.version>
         <io.opentracing.version>0.33.0</io.opentracing.version>
         <io.grpc.version>1.23.0</io.grpc.version>
         <io.netty.version>2.0.25.Final</io.netty.version>


### PR DESCRIPTION
* B3 sampled flag uses the new 0/1 format.