### PR TITLE
add tracer-grpc with required dependencies to jre-bundle, shade okhttp

### DIFF
--- a/lightstep-tracer-jre-bundle/assembly.xml
+++ b/lightstep-tracer-jre-bundle/assembly.xml
@@ -7,6 +7,12 @@
     <format>jar</format>
   </formats>
   <includeBaseDirectory>false</includeBaseDirectory>
+  <files>
+    <file>
+      <source>src/main/resources/META-INF/services/com.lightstep.tracer.shared.CollectorClientProvider</source>
+      <outputDirectory>META-INF/services</outputDirectory>
+    </file>
+  </files>
   <dependencySets>
     <dependencySet>
       <outputDirectory>/</outputDirectory>

--- a/lightstep-tracer-jre-bundle/pom.xml
+++ b/lightstep-tracer-jre-bundle/pom.xml
@@ -152,15 +152,15 @@
                 <relocations>
                   <relocation>
                     <pattern>okhttp</pattern>
-                    <shadedPattern>shaded.okhttp</shadedPattern>
+                    <shadedPattern>lightstep.okhttp</shadedPattern>
                   </relocation>
                   <relocation>
                     <pattern>io.grpc</pattern>
-                    <shadedPattern>shaded.io.grpc</shadedPattern>
+                    <shadedPattern>lightstep.io.grpc</shadedPattern>
                   </relocation>
                   <relocation>
                     <pattern>io.netty</pattern>
-                    <shadedPattern>io.shaded.netty</shadedPattern>
+                    <shadedPattern>lightstep.io.netty</shadedPattern>
                   </relocation>
                 </relocations>
               </configuration>

--- a/lightstep-tracer-jre-bundle/pom.xml
+++ b/lightstep-tracer-jre-bundle/pom.xml
@@ -145,10 +145,22 @@
               <configuration>
                 <createSourcesJar>true</createSourcesJar>
                 <shadeSourcesContent>true</shadeSourcesContent>
+                <shadedArtifactAttached>true</shadedArtifactAttached>
+                <transformers>
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                </transformers>
                 <relocations>
                   <relocation>
                     <pattern>okhttp</pattern>
                     <shadedPattern>shaded.okhttp</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>io.grpc</pattern>
+                    <shadedPattern>shaded.io.grpc</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>io.netty</pattern>
+                    <shadedPattern>io.shaded.netty</shadedPattern>
                   </relocation>
                 </relocations>
               </configuration>

--- a/lightstep-tracer-jre-bundle/pom.xml
+++ b/lightstep-tracer-jre-bundle/pom.xml
@@ -40,6 +40,24 @@
         <scope>provided</scope>
       </dependency>
       <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>tracer-grpc</artifactId>
+        <version>${lightstep.parent.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-netty</artifactId>
+        <version>${io.grpc.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>${io.netty.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
         <groupId>io.opentracing</groupId>
         <artifactId>opentracing-api</artifactId>
         <version>${io.opentracing.version}</version>
@@ -111,6 +129,29 @@
               <goals>
                 <goal>jar</goal>
               </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-shade-plugin</artifactId>
+          <version>3.2.4</version>
+          <executions>
+            <execution>
+              <phase>package</phase>
+              <goals>
+                <goal>shade</goal>
+              </goals>
+              <configuration>
+                <createSourcesJar>true</createSourcesJar>
+                <shadeSourcesContent>true</shadeSourcesContent>
+                <relocations>
+                  <relocation>
+                    <pattern>okhttp</pattern>
+                    <shadedPattern>shaded.okhttp</shadedPattern>
+                  </relocation>
+                </relocations>
+              </configuration>
             </execution>
           </executions>
         </plugin>

--- a/lightstep-tracer-jre-bundle/pom.xml
+++ b/lightstep-tracer-jre-bundle/pom.xml
@@ -145,11 +145,22 @@
               <configuration>
                 <createSourcesJar>true</createSourcesJar>
                 <shadeSourcesContent>true</shadeSourcesContent>
-                <shadedArtifactAttached>true</shadedArtifactAttached>
                 <transformers>
                   <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
                 </transformers>
                 <relocations>
+                  <relocation>
+                    <pattern>com.google</pattern>
+                    <shadedPattern>lightstep.com.google</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>google.protobuf</pattern>
+                    <shadedPattern>lightstep.google.protobuf</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>javax.annotation</pattern>
+                    <shadedPattern>lightstep.javax.annotation</shadedPattern>
+                  </relocation>
                   <relocation>
                     <pattern>okhttp</pattern>
                     <shadedPattern>lightstep.okhttp</shadedPattern>
@@ -157,10 +168,6 @@
                   <relocation>
                     <pattern>io.grpc</pattern>
                     <shadedPattern>lightstep.io.grpc</shadedPattern>
-                  </relocation>
-                  <relocation>
-                    <pattern>io.netty</pattern>
-                    <shadedPattern>lightstep.io.netty</shadedPattern>
                   </relocation>
                 </relocations>
               </configuration>

--- a/lightstep-tracer-jre-bundle/pom.xml
+++ b/lightstep-tracer-jre-bundle/pom.xml
@@ -169,6 +169,18 @@
                     <pattern>io.grpc</pattern>
                     <shadedPattern>lightstep.io.grpc</shadedPattern>
                   </relocation>
+                  <relocation>
+                    <pattern>io.netty</pattern>
+                    <shadedPattern>lightstep.io.netty</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>META-INF/native/libnetty</pattern>
+                    <shadedPattern>META-INF/native/liblightstep_netty</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>META-INF/native/netty</pattern>
+                    <shadedPattern>META-INF/native/lightstep_netty</shadedPattern>
+                  </relocation>
                 </relocations>
               </configuration>
             </execution>

--- a/lightstep-tracer-jre-bundle/src/main/resources/META-INF/services/com.lightstep.tracer.shared.CollectorClientProvider
+++ b/lightstep-tracer-jre-bundle/src/main/resources/META-INF/services/com.lightstep.tracer.shared.CollectorClientProvider
@@ -1,0 +1,2 @@
+com.lightstep.tracer.shared.HttpCollectorClientProvider
+com.lightstep.tracer.shared.GrpcCollectorClientProvider


### PR DESCRIPTION
#243 
what I found is that it's critical to test jre-bundle with real application.
if I shade `io.netty` then tracer started but spans are not sent. Although unit tests passed.
if I shade `io.grpc` then tracer failed to start. Although unit tests passed.
therefore I shade only `okhttp`
also it's important to verify that configured tracer collector is picked up (grpc or okhttp). I did it manually debugging test application and changing configuration. Without my changes in `CollectorClientProvider` grpc collector is never picked up.

so it's quite confusing that unit tests cannot verify functionality and manual testing with some debugging is required.