### PR TITLE
Don't recreate the sources jar the the bundle artifact.

### DIFF
--- a/lightstep-tracer-jre-bundle/pom.xml
+++ b/lightstep-tracer-jre-bundle/pom.xml
@@ -153,7 +153,7 @@
                 <goal>shade</goal>
               </goals>
               <configuration>
-                <createSourcesJar>true</createSourcesJar>
+                <createSourcesJar>false</createSourcesJar>
                 <shadeSourcesContent>true</shadeSourcesContent>
                 <transformers>
                   <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>


### PR DESCRIPTION
These caused two sources artifacts, which made the deployment phase fail.